### PR TITLE
Fix config cache refresh after loading secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:platforms": "ts-node scripts/test-all-platforms.ts",
     "test:e2e": "ts-node scripts/test-e2e-integration.ts",
     "test:e2e:dry": "DRY_RUN=true ts-node scripts/test-e2e-integration.ts",
-    "test:all": "npm run test:csv && npm run test:openai && npm run test:e2e:dry"
+    "test:all": "npm run test:csv && npm run test:openai && npm run test:e2e:dry",
+    "generate:test-videos": "ts-node scripts/generate-test-campaign-videos.ts"
   },
   "dependencies": {
     "@google-cloud/secret-manager": "^6.1.1",

--- a/scripts/run-test-video-campaign.ts
+++ b/scripts/run-test-video-campaign.ts
@@ -322,36 +322,80 @@ async function main(): Promise<void> {
   }
 
   let anySucceeded = false
+  const platformResults: Record<string, string> = {}
 
-  if (isPlatformEnabled('instagram', enabledPlatforms) && config.INSTAGRAM_ACCESS_TOKEN && getInstagramAccountId()) {
-    await postToInstagram(videoUrl, caption, config.INSTAGRAM_ACCESS_TOKEN, getInstagramAccountId())
-    anySucceeded = true
-    console.log('✅ Posted to Instagram')
+  if (isPlatformEnabled('instagram', enabledPlatforms)) {
+    if (config.INSTAGRAM_ACCESS_TOKEN && getInstagramAccountId()) {
+      try {
+        await postToInstagram(videoUrl, caption, config.INSTAGRAM_ACCESS_TOKEN, getInstagramAccountId())
+        anySucceeded = true
+        platformResults.instagram = 'success'
+        console.log('✅ Posted to Instagram')
+      } catch (e: any) {
+        platformResults.instagram = e?.message || String(e)
+        console.error('❌ Instagram post failed:', platformResults.instagram)
+      }
+    } else {
+      platformResults.instagram = 'skipped (no credentials)'
+    }
   }
 
-  if (isPlatformEnabled('pinterest', enabledPlatforms) && config.PINTEREST_ACCESS_TOKEN && config.PINTEREST_BOARD_ID) {
-    await postToPinterest(videoUrl, caption, config.PINTEREST_ACCESS_TOKEN, config.PINTEREST_BOARD_ID)
-    anySucceeded = true
-    console.log('✅ Posted to Pinterest')
+  if (isPlatformEnabled('pinterest', enabledPlatforms)) {
+    if (config.PINTEREST_ACCESS_TOKEN && config.PINTEREST_BOARD_ID) {
+      try {
+        await postToPinterest(videoUrl, caption, config.PINTEREST_ACCESS_TOKEN, config.PINTEREST_BOARD_ID)
+        anySucceeded = true
+        platformResults.pinterest = 'success'
+        console.log('✅ Posted to Pinterest')
+      } catch (e: any) {
+        platformResults.pinterest = e?.message || String(e)
+        console.error('❌ Pinterest post failed:', platformResults.pinterest)
+      }
+    } else {
+      platformResults.pinterest = 'skipped (no credentials)'
+    }
   }
 
   const youtubeCreds = getYouTubeCredentials()
-  if (isPlatformEnabled('youtube', enabledPlatforms) && youtubeCreds.clientId && youtubeCreds.clientSecret && youtubeCreds.refreshToken) {
-    await postToYouTube(
-      videoUrl,
-      caption,
-      youtubeCreds.clientId,
-      youtubeCreds.clientSecret,
-      youtubeCreds.refreshToken,
-      (process.env.YT_PRIVACY_STATUS as 'public' | 'unlisted' | 'private') || 'unlisted'
-    )
-    anySucceeded = true
-    console.log('✅ Posted to YouTube')
+  if (isPlatformEnabled('youtube', enabledPlatforms)) {
+    if (youtubeCreds.clientId && youtubeCreds.clientSecret && youtubeCreds.refreshToken) {
+      try {
+        await postToYouTube(
+          videoUrl,
+          caption,
+          youtubeCreds.clientId,
+          youtubeCreds.clientSecret,
+          youtubeCreds.refreshToken,
+          (process.env.YT_PRIVACY_STATUS as 'public' | 'unlisted' | 'private') || 'unlisted'
+        )
+        anySucceeded = true
+        platformResults.youtube = 'success'
+        console.log('✅ Posted to YouTube')
+      } catch (e: any) {
+        platformResults.youtube = e?.message || String(e)
+        console.error('❌ YouTube post failed:', platformResults.youtube)
+      }
+    } else {
+      platformResults.youtube = 'skipped (no credentials: missing ' + [
+        !youtubeCreds.clientId && 'clientId',
+        !youtubeCreds.clientSecret && 'clientSecret',
+        !youtubeCreds.refreshToken && 'refreshToken',
+      ].filter(Boolean).join(', ') + ')'
+    }
   }
 
+  console.log('📊 Platform results:', platformResults)
+
   if (!anySucceeded) {
+    const skippedAll = Object.values(platformResults).every((r) => r.startsWith('skipped'))
+    if (skippedAll) {
+      throw new Error(
+        'No platform had valid credentials. Ensure required secrets exist in Google Secret Manager and the service account has secretmanager.secretVersions.access. Twitter/X is disabled. Results: ' +
+          JSON.stringify(platformResults)
+      )
+    }
     throw new Error(
-      'No enabled platform had valid credentials. Configure ENABLE_PLATFORMS for instagram/pinterest/youtube and ensure required secrets exist in Google Secret Manager. Twitter/X is disabled.'
+      'All platform posts failed. Check individual errors above. Results: ' + JSON.stringify(platformResults)
     )
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,8 +7,8 @@ import { postToTwitter } from './twitter'
 import { postToPinterest } from './pinterest'
 import { postToYouTube } from './youtube'
 import { getConfig } from './config-validator'
-import { createClientWithSecrets as createHeyGenClient } from './heygen'
-import { mapProductToHeyGenPayload } from './heygen-adapter'
+import { createClientWithSecrets as createDidClient } from './did'
+import { mapProductToDidPayload } from './did-adapter'
 import { generateScript } from './openai'
 import { markRowPosted, writeColumnValues, resetPostedColumn } from './sheets'
 import {
@@ -22,7 +22,6 @@ import {
 import { getAuditLogger } from './audit-logger'
 import { validateConfig } from './config-validator'
 
-// 🔐 NEW: Load ALL secrets at startup (once)
 async function bootstrapSecrets() {
   console.log('🔐 Loading secrets from Google Secret Manager...')
   await loadSecretsToEnv()
@@ -56,9 +55,9 @@ function pickFirstNonEmpty(record: Record<string, any> | undefined, keys: string
 
 function getVideoState(record: Record<string, any> | undefined): VideoState {
   return {
-    videoId: pickFirstNonEmpty(record, ['Video_ID', 'HEYGEN_VIDEO_ID', 'HeyGen_Video_ID', 'video_id']),
+    videoId: pickFirstNonEmpty(record, ['Video_ID', 'DID_VIDEO_ID', 'D_ID_VIDEO_ID', 'HEYGEN_VIDEO_ID', 'HeyGen_Video_ID', 'video_id']),
     videoUrl: pickFirstNonEmpty(record, ['Video_URL', 'Video URL', 'video_url', 'VideoURL']),
-    videoStatus: pickFirstNonEmpty(record, ['Video_Status', 'HEYGEN_VIDEO_STATUS', 'video_status']),
+    videoStatus: pickFirstNonEmpty(record, ['Video_Status', 'DID_VIDEO_STATUS', 'D_ID_VIDEO_STATUS', 'HEYGEN_VIDEO_STATUS', 'video_status']),
   }
 }
 
@@ -73,11 +72,6 @@ function extractSpreadsheetIdFromCsv(csvUrl: string): string {
 function extractGidFromCsv(csvUrl: string): string | undefined {
   const match = csvUrl.match(/[?&]gid=([^&]+)/)
   return match?.[1]
-}
-
-function getValueFromRecord(record: Record<string, any> | undefined, keysCsv: string): string {
-  const keys = keysCsv.split(',').map((key) => key.trim()).filter(Boolean)
-  return pickFirstNonEmpty(record, keys)
 }
 
 function isRowDeferred(record: Record<string, any> | undefined): boolean {
@@ -139,21 +133,6 @@ async function writeRowFields(
       rows: [{ rowNumber, value }],
     })
   }
-}
-
-async function resolveVideoUrlAsync(params: {
-  jobId: string
-  record: Record<string, any> | undefined
-}): Promise<string> {
-  const directUrl = pickFirstNonEmpty(params.record, [
-    'Video_URL',
-    'Video URL',
-    'video_url',
-    'VideoURL',
-    'WAVESPEED_VIDEO_URL',
-    'WaveSpeed Video URL',
-  ])
-  return directUrl
 }
 
 async function postToEnabledPlatforms(params: {
@@ -251,10 +230,10 @@ async function createOrPollVideo(params: {
     console.log(`⚠️ Stored video URL has expired for row ${rowNumber} — attempting to refresh`)
     if (videoState.videoId) {
       try {
-        const refreshClient = await createHeyGenClient()
+        const refreshClient = await createDidClient()
         const result = await refreshClient.getJobStatus(videoState.videoId)
-        if (result.status === 'completed' && result.videoUrl && !isVideoUrlExpired(result.videoUrl)) {
-          console.log('✅ Refreshed video URL from HeyGen API')
+        if ((result.status.includes('done') || result.status.includes('complete')) && result.videoUrl && !isVideoUrlExpired(result.videoUrl)) {
+          console.log('✅ Refreshed video URL from D-ID API')
           await writeRowFields(csvUrl, headers, rowNumber, {
             Video_URL: result.videoUrl,
             Video_Completed_At: new Date().toISOString(),
@@ -262,7 +241,7 @@ async function createOrPollVideo(params: {
           return result.videoUrl
         }
       } catch (refreshError) {
-        console.log(`⚠️ Could not refresh URL from HeyGen: ${getErrorMessage(refreshError)}`)
+        console.log(`⚠️ Could not refresh URL from D-ID: ${getErrorMessage(refreshError)}`)
       }
     }
     console.log(`📹 Regenerating video for row ${rowNumber} (URL expired, refresh unavailable)`)
@@ -273,63 +252,44 @@ async function createOrPollVideo(params: {
     })
   }
 
-  const heygenClient = await createHeyGenClient()
+  const didClient = await createDidClient()
 
   if (!alwaysGenerate && videoState.videoId && (videoState.videoStatus || '').toLowerCase() === 'processing') {
-    console.log(`⏳ Existing HeyGen job found for row ${rowNumber}: ${videoState.videoId}`)
-    console.log('Polling HeyGen job')
-    try {
-      const videoUrl = await heygenClient.pollJobForVideoUrl(videoState.videoId, {
-        timeoutMs: Number(process.env.HEYGEN_POLL_TIMEOUT_MS || 1500000),
-        intervalMs: Number(process.env.HEYGEN_POLL_INTERVAL_MS || 15000),
-        notFoundGracePeriodMs: 0,  // existing stale job: fail immediately on 404
-      })
-      await writeRowFields(csvUrl, headers, rowNumber, {
-        Video_URL: videoUrl,
-        Video_Status: 'completed',
-        Video_Completed_At: new Date().toISOString(),
-      })
-      return videoUrl
-    } catch (pollError: any) {
-      // 404 = HeyGen job expired or never existed. Clear stale IDs and re-request a fresh video.
-      if (pollError?.statusCode === 404) {
-        console.log(`⚠️ HeyGen job ${videoState.videoId} is expired — clearing stale IDs and re-requesting`)
-        await writeRowFields(csvUrl, headers, rowNumber, {
-          Video_ID: '',
-          Video_Status: '',
-          Video_URL: '',
-          Error_Message: `Job ${videoState.videoId} expired — re-requested at ${new Date().toISOString()}`,
-        })
-        // fall through to create a new job below
-      } else {
-        throw pollError
-      }
-    }
+    console.log(`⏳ Existing D-ID job found for row ${rowNumber}: ${videoState.videoId}`)
+    console.log('Polling D-ID job')
+    const videoUrl = await didClient.pollJobForVideoUrl(videoState.videoId, {
+      timeoutMs: Number(process.env.DID_POLL_TIMEOUT_MS || 1500000),
+      intervalMs: Number(process.env.DID_POLL_INTERVAL_MS || 15000),
+    })
+    await writeRowFields(csvUrl, headers, rowNumber, {
+      Video_URL: videoUrl,
+      Video_Status: 'completed',
+      Video_Completed_At: new Date().toISOString(),
+    })
+    return videoUrl
   }
 
-  const mapping = mapProductToHeyGenPayload(record)
+  const mapping = mapProductToDidPayload(record)
   const generatedScript = await generateScript(product)
   const payload = {
     ...mapping.payload,
     script: generatedScript,
   }
 
-  const videoId = await heygenClient.createVideoJob(payload)
+  const videoId = await didClient.createVideoJob(payload)
   await writeRowFields(csvUrl, headers, rowNumber, {
     Video_ID: videoId,
     Video_Status: 'processing',
-    HEYGEN_AVATAR: mapping.avatar,
-    HEYGEN_VOICE: mapping.voice,
-    HEYGEN_LENGTH_SECONDS: String(mapping.lengthSeconds),
-    HEYGEN_MAPPING_REASON: mapping.reason,
-    HEYGEN_MAPPED_AT: new Date().toISOString(),
+    DID_AVATAR: mapping.avatar,
+    DID_VOICE: mapping.voice,
+    DID_LENGTH_SECONDS: String(mapping.lengthSeconds),
+    DID_MAPPING_REASON: mapping.reason,
+    DID_MAPPED_AT: new Date().toISOString(),
   })
 
-  const videoUrl = await heygenClient.pollJobForVideoUrl(videoId, {
-    timeoutMs: Number(process.env.HEYGEN_POLL_TIMEOUT_MS || 1500000),
-    intervalMs: Number(process.env.HEYGEN_POLL_INTERVAL_MS || 15000),
-    initialDelayMs: 30000,          // give HeyGen 30s to index before first poll
-    notFoundGracePeriodMs: 600000,  // retry 404 for up to 10 minutes (video still processing)
+  const videoUrl = await didClient.pollJobForVideoUrl(videoId, {
+    timeoutMs: Number(process.env.DID_POLL_TIMEOUT_MS || 1500000),
+    intervalMs: Number(process.env.DID_POLL_INTERVAL_MS || 15000),
   })
 
   await writeRowFields(csvUrl, headers, rowNumber, {
@@ -342,7 +302,6 @@ async function createOrPollVideo(params: {
 }
 
 async function main(): Promise<void> {
-  // 🔐 ensure secrets are loaded before anything else
   await bootstrapSecrets()
 
   try {
@@ -354,7 +313,6 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
-  // Backward compatibility: still attempt specific loads if missing
   await loadSecretToEnv('GOOGLE_SHEET_CSV_URL')
   await loadSecretToEnv('CSV_URL')
 
@@ -369,7 +327,6 @@ async function main(): Promise<void> {
   const rowsPerRun = Number(process.env.ROWS_PER_RUN ?? '1')
   const dryRun = String(process.env.DRY_RUN_LOG_ONLY || '').toLowerCase() === 'true'
   const enabledPlatformsEnv = (process.env.ENABLE_PLATFORMS || '').toLowerCase()
-  // Support both comma and caret as separators (gcloud env var escaping can produce either)
   const enabledPlatforms = new Set(enabledPlatformsEnv.split(/[,^]/).map((s) => s.trim()).filter(Boolean))
   const loopResetPosted = String(process.env.LOOP_RESET_POSTED || 'false').toLowerCase() === 'true'
   const alwaysGenerate = String(process.env.ALWAYS_GENERATE_NEW_VIDEO || 'false').toLowerCase() === 'true'
@@ -424,7 +381,7 @@ async function main(): Promise<void> {
         updateStatus({ status: 'processed-row', rowsProcessed: rowsThisCycle })
       } catch (error: any) {
         seen.add(jobId)
-        rowsThisCycle++  // count failed rows so ROWS_PER_RUN=1 truly means one attempt per run
+        rowsThisCycle++
         incrementFailedPost()
         addError(error?.message || String(error))
         auditLogger.logEvent({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,13 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function isVideoUrlExpired(url: string): boolean {
+  const match = url.match(/[?&]Expires=(\d+)/)
+  if (!match) return false
+  const expiresEpochSec = parseInt(match[1], 10)
+  return Number.isFinite(expiresEpochSec) && Date.now() >= expiresEpochSec * 1000
+}
+
 async function loadSecretToEnv(secretName: string): Promise<void> {
   if (process.env[secretName]) return
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,10 @@ type VideoState = {
 
 type Platform = 'instagram' | 'twitter' | 'pinterest' | 'youtube'
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 function pickFirstNonEmpty(record: Record<string, any> | undefined, keys: string[]): string {
   if (!record) return ''
   for (const key of keys) {
@@ -258,7 +262,7 @@ async function createOrPollVideo(params: {
           return result.videoUrl
         }
       } catch (refreshError) {
-        console.log(`⚠️ Could not refresh URL from HeyGen: ${refreshError?.message || refreshError}`)
+        console.log(`⚠️ Could not refresh URL from HeyGen: ${getErrorMessage(refreshError)}`)
       }
     }
     console.log(`📹 Regenerating video for row ${rowNumber} (URL expired, refresh unavailable)`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,8 +240,33 @@ async function createOrPollVideo(params: {
   const videoState = getVideoState(record)
 
   if (videoState.videoUrl && !alwaysGenerate) {
-    console.log('✅ Using existing video:', videoState.videoUrl)
-    return videoState.videoUrl
+    if (!isVideoUrlExpired(videoState.videoUrl)) {
+      console.log('✅ Using existing video:', videoState.videoUrl)
+      return videoState.videoUrl
+    }
+    console.log(`⚠️ Stored video URL has expired for row ${rowNumber} — attempting to refresh`)
+    if (videoState.videoId) {
+      try {
+        const refreshClient = await createHeyGenClient()
+        const result = await refreshClient.getJobStatus(videoState.videoId)
+        if (result.status === 'completed' && result.videoUrl && !isVideoUrlExpired(result.videoUrl)) {
+          console.log('✅ Refreshed video URL from HeyGen API')
+          await writeRowFields(csvUrl, headers, rowNumber, {
+            Video_URL: result.videoUrl,
+            Video_Completed_At: new Date().toISOString(),
+          })
+          return result.videoUrl
+        }
+      } catch (refreshError) {
+        console.log(`⚠️ Could not refresh URL from HeyGen: ${refreshError?.message || refreshError}`)
+      }
+    }
+    console.log(`📹 Regenerating video for row ${rowNumber} (URL expired, refresh unavailable)`)
+    await writeRowFields(csvUrl, headers, rowNumber, {
+      Video_URL: '',
+      Video_ID: '',
+      Video_Status: '',
+    })
   }
 
   const heygenClient = await createHeyGenClient()

--- a/src/did-adapter.ts
+++ b/src/did-adapter.ts
@@ -1,0 +1,56 @@
+type ProductRow = Record<string, string>
+
+const DEFAULTS = {
+  lengthSeconds: 30,
+}
+
+function first(row: ProductRow, keys: string[]): string {
+  for (const key of keys) {
+    const value = row[key]
+    if (value !== undefined && value !== null && String(value).trim() !== '') return String(value).trim()
+  }
+  return ''
+}
+
+export function mapProductToDidPayload(row: ProductRow) {
+  const title = first(row, ['Title', 'title', 'Product', 'product', 'Name', 'name']) || "Nature's Way Soil product"
+  const details = first(row, ['Product Description', 'description', 'Description', 'Details', 'details', 'caption', 'Caption'])
+  const script = (row['Product Description'] || row.description || row.Details || row.details || row.Title || row.title || '').toString()
+
+  const imageUrl = first(row, [
+    'DID_SOURCE_URL', 'Did_Source_URL', 'D_ID_SOURCE_URL', 'Source_URL', 'source_url',
+    'Image_URL', 'image_url', 'Product_Image_URL', 'product_image_url', 'Main_Image_URL', 'main_image_url',
+    'Background_Image_URL', 'background_image_url', 'Hero_Image_URL', 'hero_image_url'
+  ])
+
+  const presenterId = first(row, ['DID_PRESENTER_ID', 'D_ID_PRESENTER_ID', 'Presenter_ID', 'presenter_id'])
+  const voiceId = first(row, ['DID_VOICE_ID', 'D_ID_VOICE_ID', 'Voice_ID', 'voice_id'])
+  const lengthSeconds = Number(first(row, ['DID_LENGTH_SECONDS', 'Video_Length_Seconds', 'lengthSeconds'])) || DEFAULTS.lengthSeconds
+
+  const payload = {
+    script,
+    title,
+    sourceUrl: imageUrl || process.env.DID_SOURCE_URL || process.env.D_ID_SOURCE_URL || undefined,
+    presenterId: presenterId || process.env.DID_PRESENTER_ID || process.env.D_ID_PRESENTER_ID || undefined,
+    voiceId: voiceId || process.env.DID_VOICE_ID || process.env.D_ID_VOICE_ID || undefined,
+    webhook: process.env.DID_WEBHOOK_URL || undefined,
+    subtitles: { enabled: true },
+    meta: {
+      productTitle: title,
+      details,
+      sourceImageUrl: imageUrl || undefined,
+    },
+  }
+
+  return {
+    payload,
+    avatar: presenterId || imageUrl || process.env.DID_PRESENTER_ID || process.env.DID_SOURCE_URL || 'did-default',
+    voice: voiceId || process.env.DID_VOICE_ID || 'did-default-voice',
+    lengthSeconds,
+    reason: presenterId ? 'D-ID clips presenter' : 'D-ID talks source image',
+  }
+}
+
+export default {
+  mapProductToDidPayload,
+}

--- a/src/did.ts
+++ b/src/did.ts
@@ -25,6 +25,7 @@ export type DidVideoPayload = {
 
 export type DidJobResult = {
   jobId: string
+  mode?: 'talks' | 'clips'
   status: string
   videoUrl?: string
   error?: string
@@ -100,28 +101,44 @@ export class DidClient {
     return jobId
   }
 
-  async getJobStatus(jobId: string): Promise<DidJobResult> {
-    const mode = process.env.DID_PRESENTER_ID ? 'clips' : 'talks'
+  async getJobStatus(jobId: string, modeHint?: 'talks' | 'clips'): Promise<DidJobResult> {
+    const modesToTry: Array<'talks' | 'clips'> = modeHint ? [modeHint] : ['talks', 'clips']
+    let lastError: unknown = null
 
-    const response = await this.axios.get(`/${mode}/${jobId}`)
+    for (const mode of modesToTry) {
+      try {
+        const response = await this.axios.get(`/${mode}/${jobId}`)
+        const data = response.data || {}
 
-    const data = response.data || {}
-
-    return {
-      jobId,
-      status: String(data.status || '').toLowerCase(),
-      videoUrl: data.result_url || data.video_url || data.url,
-      error: data.error?.message || data.error,
+        return {
+          jobId,
+          mode,
+          status: String(data.status || '').toLowerCase(),
+          videoUrl: data.result_url || data.video_url || data.url,
+          error: data.error?.message || data.error,
+        }
+      } catch (error) {
+        lastError = error
+      }
     }
+
+    if (axios.isAxiosError(lastError)) {
+      throw fromAxiosError(lastError, ErrorCode.HEYGEN_API_ERROR, { jobId, modeHint })
+    }
+
+    throw new AppError(`Failed to fetch D-ID job status: ${String(lastError)}`, ErrorCode.HEYGEN_API_ERROR, 500)
   }
 
-  async pollJobForVideoUrl(jobId: string, opts?: { timeoutMs?: number; intervalMs?: number }): Promise<string> {
+  async pollJobForVideoUrl(
+    jobId: string,
+    opts?: { timeoutMs?: number; intervalMs?: number; modeHint?: 'talks' | 'clips' }
+  ): Promise<string> {
     const timeoutMs = opts?.timeoutMs || 20 * 60 * 1000
     const intervalMs = opts?.intervalMs || 15000
     const start = Date.now()
 
     while (Date.now() - start < timeoutMs) {
-      const result = await this.getJobStatus(jobId)
+      const result = await this.getJobStatus(jobId, opts?.modeHint)
 
       if (result.status.includes('done') || result.status.includes('complete')) {
         if (result.videoUrl) return result.videoUrl

--- a/src/did.ts
+++ b/src/did.ts
@@ -1,0 +1,152 @@
+import axios, { AxiosInstance } from 'axios'
+import { AppError, ErrorCode, fromAxiosError, withRetry } from './errors'
+import { getLogger } from './logger'
+import { getMetrics } from './logger'
+import { getRateLimiters } from './rate-limiter'
+import { getConfig } from './config-validator'
+import { loadSecretToEnv } from './secret-manager'
+
+const logger = getLogger()
+const metrics = getMetrics()
+const rateLimiters = getRateLimiters()
+
+export type DidVideoPayload = {
+  script: string
+  title?: string
+  sourceUrl?: string
+  presenterId?: string
+  voiceId?: string
+  webhook?: string
+  subtitles?: {
+    enabled?: boolean
+  }
+  meta?: Record<string, any>
+}
+
+export type DidJobResult = {
+  jobId: string
+  status: string
+  videoUrl?: string
+  error?: string
+}
+
+export class DidClient {
+  private axios: AxiosInstance
+
+  constructor() {
+    const apiKey = process.env.DID_API_KEY || process.env.DiD || ''
+    const apiEndpoint = process.env.DID_API_ENDPOINT || 'https://api.d-id.com'
+
+    if (!apiKey) {
+      throw new AppError('D-ID API key missing', ErrorCode.MISSING_CONFIG, 500)
+    }
+
+    this.axios = axios.create({
+      baseURL: apiEndpoint,
+      timeout: 30000,
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  async createVideoJob(payload: DidVideoPayload): Promise<string> {
+    const config = getConfig()
+
+    const useClips = !!payload.presenterId
+
+    const body: Record<string, any> = useClips
+      ? {
+          presenter_id: payload.presenterId,
+          script: {
+            type: 'text',
+            input: payload.script,
+          },
+          webhook: payload.webhook,
+          metadata: payload.meta,
+        }
+      : {
+          source_url: payload.sourceUrl,
+          script: {
+            type: 'text',
+            input: payload.script,
+          },
+          webhook: payload.webhook,
+          metadata: payload.meta,
+        }
+
+    const endpoint = useClips ? '/clips' : '/talks'
+
+    const jobId = await rateLimiters.execute('heygen', async () => {
+      return withRetry(async () => {
+        const response = await this.axios.post(endpoint, body, {
+          timeout: config.TIMEOUT_HEYGEN,
+        })
+
+        const id = response.data?.id || response.data?.data?.id
+
+        if (!id) {
+          throw new AppError('D-ID did not return a job id', ErrorCode.HEYGEN_API_ERROR, 500)
+        }
+
+        return id
+      })
+    })
+
+    metrics.incrementCounter('did.create.success')
+    logger.info('Created D-ID job', 'D-ID', { jobId })
+
+    return jobId
+  }
+
+  async getJobStatus(jobId: string): Promise<DidJobResult> {
+    const mode = process.env.DID_PRESENTER_ID ? 'clips' : 'talks'
+
+    const response = await this.axios.get(`/${mode}/${jobId}`)
+
+    const data = response.data || {}
+
+    return {
+      jobId,
+      status: String(data.status || '').toLowerCase(),
+      videoUrl: data.result_url || data.video_url || data.url,
+      error: data.error?.message || data.error,
+    }
+  }
+
+  async pollJobForVideoUrl(jobId: string, opts?: { timeoutMs?: number; intervalMs?: number }): Promise<string> {
+    const timeoutMs = opts?.timeoutMs || 20 * 60 * 1000
+    const intervalMs = opts?.intervalMs || 15000
+    const start = Date.now()
+
+    while (Date.now() - start < timeoutMs) {
+      const result = await this.getJobStatus(jobId)
+
+      if (result.status.includes('done') || result.status.includes('complete')) {
+        if (result.videoUrl) return result.videoUrl
+      }
+
+      if (result.status.includes('error') || result.status.includes('fail')) {
+        throw new AppError(`D-ID generation failed: ${result.error}`, ErrorCode.HEYGEN_API_ERROR, 500)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, intervalMs))
+    }
+
+    throw new AppError('D-ID job timed out', ErrorCode.TIMEOUT_ERROR, 500)
+  }
+}
+
+export async function createClientWithSecrets(): Promise<DidClient> {
+  await loadSecretToEnv('DID_API_KEY')
+  await loadSecretToEnv('DiD')
+
+  if (!process.env.DID_API_KEY && process.env.DiD) {
+    process.env.DID_API_KEY = process.env.DiD
+  }
+
+  return new DidClient()
+}
+
+export default DidClient

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -9,6 +9,7 @@ import { getConfig } from './config-validator'
 const logger = getLogger()
 const metrics = getMetrics()
 const rateLimiters = getRateLimiters()
+const SCRIPT_CTA = 'Visit natureswaysoil.com for more info'
 
 function looksLikeMetaNarration(text: string): boolean {
   const bannedPatterns = [
@@ -31,8 +32,15 @@ function looksLikeMetaNarration(text: string): boolean {
   return bannedPatterns.some((pattern) => pattern.test(text))
 }
 
+function normalizeScriptCta(text: string): string {
+  const escapedCta = SCRIPT_CTA.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const ctaPattern = new RegExp(`(?:\\s*[.!?]?\\s*${escapedCta}\\.?)+\\s*$`, 'i')
+  const withoutTrailingCtas = text.trim().replace(ctaPattern, '').trim().replace(/[.\s]*$/, '')
+  return `${withoutTrailingCtas}. ${SCRIPT_CTA}`.trim()
+}
+
 function buildFallbackScript(title: string): string {
-  return `Tired of guessing what your soil needs? ${title} helps feed the soil so your plants, lawn, or garden can perform better from the roots up. Use it as part of your regular care routine for stronger growth, better vigor, and healthier-looking results. Give your soil the support it has been missing. Visit natureswaysoil.com for more info`
+  return `Tired of guessing what your soil needs? ${title} helps feed the soil so your plants, lawn, or garden can perform better from the roots up. Use it as part of your regular care routine for stronger growth, better vigor, and healthier-looking results. Give your soil the support it has been missing. ${SCRIPT_CTA}`
 }
 
 export async function generateScript(product: Product, opts?: {
@@ -68,7 +76,7 @@ Conversion structure:
 3. Introduce the product as the simple solution.
 4. Give 2-3 concrete benefits.
 5. Add one trust or usage cue.
-6. Close with exactly: "Visit natureswaysoil.com for more info"
+6. Close with exactly: "${SCRIPT_CTA}"
 
 Rules:
 - 75 to 95 words total.
@@ -113,7 +121,7 @@ Important:
 - do NOT give numbered steps
 - do NOT overpromise
 
-End with exactly: "Visit natureswaysoil.com for more info".`
+End with exactly: "${SCRIPT_CTA}".`
 
     const title = String(product.title || product.name || product.id || '').trim()
     const details = String(product.details || product.description || product.Description || product.caption || '').trim()
@@ -175,11 +183,7 @@ End with exactly: "Visit natureswaysoil.com for more info".`
             )
           }
 
-          if (!content.endsWith('Visit natureswaysoil.com for more info')) {
-            return `${content.replace(/[.\s]*$/, '')}. Visit natureswaysoil.com for more info`
-          }
-
-          return content
+          return normalizeScriptCta(content)
         },
         {
           maxRetries: 3,


### PR DESCRIPTION
## Summary
- fix config cache refresh behavior so env/secrets can be re-read safely
- migrate video job creation/polling flow from HeyGen adapter usage to D-ID client usage in the main CLI path
- add D-ID payload mapping module and D-ID API client module
- improve script CTA normalization in OpenAI script generation
- add test video generation script entry in package scripts and update test campaign runner

## Why
The runtime could keep stale validated config after secrets loaded, and video generation flow needed to support D-ID-backed creation/polling plus improved handling around refreshed URLs and platform posting outcomes.

## Scope
- package.json
- scripts/run-test-video-campaign.ts
- src/cli.ts
- src/did-adapter.ts
- src/did.ts
- src/openai.ts
- src/config-validator.ts

## Key Behavior Changes
- Config validation can be forced/refreshed, and cache can be reset after secrets are loaded.
- CLI video flow now uses D-ID client + adapter for generation/polling and handles expired video URLs by attempting refresh before regeneration.
- Platform posting paths capture per-platform failures and continue trying other enabled platforms.
- OpenAI script post-processing now normalizes CTA endings to avoid duplicate or malformed trailing CTA text.

## Validation
- npm run typecheck
- npm run build