### PR TITLE
Make blog generator product-focused and keep social posting alive

### DIFF
--- a/src/blog-generator.ts
+++ b/src/blog-generator.ts
@@ -1,11 +1,10 @@
 /**
  * Automated Blog Article & Video Generator
- * Generates gardening/soil-related blog content and creates matching videos
+ * Generates buyer-intent Nature's Way Soil blog posts and posts them for traffic.
  */
 
 import 'dotenv/config'
 import axios from 'axios'
-import { generateScript } from './openai'
 import { createClientWithSecrets } from './heygen'
 import { postToYouTube } from './youtube'
 import { postToInstagram } from './instagram'
@@ -13,9 +12,7 @@ import { postToTwitter } from './twitter'
 import { postToPinterest } from './pinterest'
 import OpenAI from 'openai'
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-})
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
 interface BlogPost {
   title: string
@@ -29,185 +26,302 @@ interface BlogPost {
   publishDate: string
 }
 
-const BLOG_TOPICS = [
-  'soil health',
-  'organic gardening',
-  'composting tips',
-  'plant nutrition',
-  'sustainable farming',
-  'garden fertilizers',
-  'soil amendments',
-  'worm castings benefits',
-  'biochar uses',
-  'hydroponic gardening',
-  'lawn care',
-  'vegetable gardening',
-  'indoor plants',
-  'orchid care',
-  'tomato growing tips'
-]
-
-/**
- * Generate a comprehensive blog article with OpenAI
- */
-export async function generateBlogArticle(): Promise<BlogPost> {
-  const topic = BLOG_TOPICS[Math.floor(Math.random() * BLOG_TOPICS.length)]
-  
-  console.log(`\n🎯 Generating blog article about: ${topic}`)
-  
-  const prompt = `You are an expert in organic gardening and soil science. Write a comprehensive, SEO-optimized blog article for Nature's Way Soil website.
-
-Topic: ${topic}
-
-Requirements:
-1. Title: Catchy, SEO-friendly (60-70 characters)
-2. Excerpt: Engaging summary (150-160 characters)
-3. Content: 1200-1800 words, well-structured with headings
-4. Include actionable tips and science-backed information
-5. Naturally mention Nature's Way Soil products where relevant
-6. Professional yet accessible tone
-7. Include a call-to-action at the end
-
-Format your response as JSON:
-{
-  "title": "...",
-  "excerpt": "...",
-  "content": "...",
-  "category": "...",
-  "tags": ["...", "..."],
-  "seoKeywords": ["...", "..."],
-  "videoPrompt": "A 15-second visual description for video generation"
+type ProductTopic = {
+  targetKeyword: string
+  buyerProblem: string
+  product: string
+  internalLink: string
+  category: string
+  tags: string[]
+  audience: string
+  visualPrompt: string
 }
 
-The content should use Markdown formatting with ## for headings.`
+const PRODUCT_TOPICS: ProductTopic[] = [
+  {
+    targetKeyword: 'dog urine spots on lawn',
+    buyerProblem: 'homeowners with yellow dog urine spots, lawn odor, and repeat pet areas',
+    product: "Dog Urine Neutralizer & Lawn Repair",
+    internalLink: 'https://natureswaysoil.com/pet-lawn-spot-odor-control',
+    category: 'Lawn Care',
+    tags: ['dog urine spots', 'pet lawn care', 'lawn repair', 'odor control'],
+    audience: 'dog owners, lawn care customers, pet facilities, and property managers',
+    visualPrompt: 'Dog on green lawn, close-up of yellow lawn spots, homeowner applying lawn-safe spray, grass recovery visuals'
+  },
+  {
+    targetKeyword: 'compacted clay soil lawn treatment',
+    buyerProblem: 'lawns and gardens where water runs off, roots stay shallow, or clay soil gets hard after heat',
+    product: 'Liquid Lawn Soil Conditioner with humic acid and kelp',
+    internalLink: 'https://natureswaysoil.com/compacted-clay-soil',
+    category: 'Soil Health',
+    tags: ['compacted soil', 'clay soil', 'liquid aeration', 'soil conditioner'],
+    audience: 'homeowners, landscapers, gardeners, and lawn care crews',
+    visualPrompt: 'Hard clay soil, water runoff, soil close-ups, lawn sprayer application, deeper grass roots'
+  },
+  {
+    targetKeyword: 'liquid biochar for soil',
+    buyerProblem: 'tired garden soil, drought-stressed lawns, weak pasture soil, and poor water retention',
+    product: 'Liquid Biochar Soil Restoration products',
+    internalLink: 'https://natureswaysoil.com/liquid-biochar-soil-restoration',
+    category: 'Soil Health',
+    tags: ['liquid biochar', 'soil restoration', 'water retention', 'soil carbon'],
+    audience: 'gardeners, landowners, pasture owners, food plot managers, and soil-health buyers',
+    visualPrompt: 'Liquid biochar mixing, dark rich soil, roots in soil, pasture and garden recovery scenes'
+  },
+  {
+    targetKeyword: 'humic acid fulvic acid kelp lawn',
+    buyerProblem: 'customers who want greener growth, better nutrient uptake, and root-zone support without a harsh program',
+    product: 'Liquid Humic & Fulvic Acid with Kelp',
+    internalLink: 'https://natureswaysoil.com/shop',
+    category: 'Product Guide',
+    tags: ['humic acid', 'fulvic acid', 'kelp', 'root growth'],
+    audience: 'homeowners, gardeners, greenhouse growers, and turf managers',
+    visualPrompt: 'Humic liquid being measured, kelp seaweed visuals, roots absorbing nutrients, green lawn close-up'
+  },
+  {
+    targetKeyword: 'pasture recovery fertilizer for horses',
+    buyerProblem: 'thin hay fields, horse pastures, food plots, and large lawns stressed by heat, drought, and low soil activity',
+    product: "Hay, Pasture & Lawn Recovery System with Liquid Biochar",
+    internalLink: 'https://natureswaysoil.com/pasture-lawn-recovery',
+    category: 'Farming',
+    tags: ['pasture recovery', 'hay field fertilizer', 'horse pasture', 'liquid biochar'],
+    audience: 'horse owners, small farms, landowners, food plot managers, and grounds crews',
+    visualPrompt: 'Horse pasture, hay field, broadcast spraying, drought stressed grass, greener recovery strips'
+  },
+  {
+    targetKeyword: 'living soil amendment for raised beds',
+    buyerProblem: 'raised beds, containers, and garden rows with tired soil, low organic matter, or weak root growth',
+    product: "Living Soil Revitalizer with worm castings and activated biochar",
+    internalLink: 'https://natureswaysoil.com/shop',
+    category: 'Organic Gardening',
+    tags: ['living soil', 'worm castings', 'activated biochar', 'raised beds'],
+    audience: 'vegetable gardeners, homesteaders, container growers, and organic gardening customers',
+    visualPrompt: 'Raised bed soil, worm castings, biochar pieces, gardener topdressing vegetables, healthy roots'
+  },
+  {
+    targetKeyword: 'grounds maintenance soil products for government facilities',
+    buyerProblem: 'parks, cemeteries, military housing, municipal grounds, and facility turf that need practical soil-support products',
+    product: 'Nature’s Way Soil grounds maintenance product line',
+    internalLink: 'https://natureswaysoil.com/government',
+    category: 'Government Grounds',
+    tags: ['government grounds', 'facility turf', 'parks maintenance', 'soil restoration'],
+    audience: 'government buyers, prime contractors, facility managers, and public works teams',
+    visualPrompt: 'Public park turf, municipal grounds crew, sprayer on facility lawn, healthy maintained grounds'
+  }
+]
 
-  try {
-    const response = await openai.chat.completions.create({
-      model: process.env.OPENAI_BLOG_MODEL || 'gpt-4o',
-      messages: [
-        {
-          role: 'system',
-          content: 'You are an expert content writer specializing in organic gardening, soil science, and sustainable agriculture.'
-        },
-        {
-          role: 'user',
-          content: prompt
-        }
-      ],
-      temperature: 0.8,
-      max_tokens: 4000,
-      response_format: { type: 'json_object' }
-    })
+function slugify(value: string): string {
+  return String(value || 'nature-way-soil-blog')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 75) || 'nature-way-soil-blog'
+}
 
-    const choice = response.choices?.[0]
-    const content = choice?.message?.content
-    if (!content) throw new Error('No content generated')
+function todayTopic(): ProductTopic {
+  const index = Math.floor(Math.random() * PRODUCT_TOPICS.length)
+  return PRODUCT_TOPICS[index]
+}
 
-    const blogData = JSON.parse(content)
-    
-    // Generate slug from title
-    const slug = blogData.title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '')
-    
-    // Add publish date
-    const publishDate = new Date().toISOString()
+function extractJson(text: string): any {
+  const match = text.match(/\{[\s\S]*\}/)
+  if (!match) throw new Error('OpenAI did not return JSON')
+  return JSON.parse(match[0])
+}
 
-    const blogPost: BlogPost = {
-      ...blogData,
-      slug,
-      publishDate
-    }
+function fallbackArticle(topic: ProductTopic): BlogPost {
+  const title = `How to Fix ${topic.targetKeyword.replace(/\b\w/g, c => c.toUpperCase())}`
+  const content = `# ${title}
 
-    console.log('✅ Blog article generated successfully!')
-    console.log(`   Title: ${blogPost.title}`)
-    console.log(`   Word Count: ~${blogPost.content.split(' ').length} words`)
-    console.log(`   Tags: ${blogPost.tags.join(', ')}`)
+## Quick answer
 
-    return blogPost
-  } catch (error: any) {
-    console.error('❌ Failed to generate blog article:', error.message)
-    throw error
+The best way to handle ${topic.targetKeyword} is to treat the soil problem, not just the surface symptom. Start with water movement, root-zone health, organic matter, and consistent application. For this buyer problem, Nature's Way Soil recommends ${topic.product}.
+
+## Why this problem happens
+
+${topic.buyerProblem} often shows up when the soil is stressed, compacted, low in biology, short on organic matter, or unable to move water and nutrients into the root zone. A quick green-up can help for a few days, but long-term improvement usually comes from supporting the soil system.
+
+## What to do first
+
+1. Identify whether the problem is fresh, repeated, or seasonal.
+2. Water the area so product and nutrients can move into the root zone.
+3. Apply according to the product label during cooler morning or evening conditions.
+4. Repeat as directed and watch for better water movement, rooting, and recovery.
+
+## Recommended Nature's Way Soil Product
+
+For this issue, look at ${topic.product}. It is built for ${topic.audience} who want a practical soil-first solution.
+
+[View the recommended Nature's Way Soil solution](${topic.internalLink})
+
+## Final tip
+
+Use the product as part of a routine instead of a one-time rescue. Soil responds best when moisture, organic matter, nutrients, and biology are supported together.
+
+Shop or request a quote at natureswaysoil.com.`
+
+  return {
+    title,
+    slug: slugify(title),
+    excerpt: `A practical soil-first guide for ${topic.targetKeyword}, with steps, product guidance, and a direct Nature's Way Soil solution.`,
+    content,
+    category: topic.category,
+    tags: topic.tags,
+    videoPrompt: topic.visualPrompt,
+    seoKeywords: [topic.targetKeyword, topic.product, ...topic.tags],
+    publishDate: new Date().toISOString(),
   }
 }
 
 /**
- * Generate video for the blog post using HeyGen
+ * Generate a comprehensive blog article with OpenAI.
+ */
+export async function generateBlogArticle(): Promise<BlogPost> {
+  const topic = todayTopic()
+  console.log(`\n🎯 Generating buyer-intent blog article about: ${topic.targetKeyword}`)
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.log('⚠️  OPENAI_API_KEY missing; using fallback article')
+    return fallbackArticle(topic)
+  }
+
+  const prompt = `Write one buyer-intent SEO blog article for Nature's Way Soil.
+
+Business: Nature's Way Soil, a small family farm in Snow Hill, NC.
+Target keyword: ${topic.targetKeyword}
+Buyer problem: ${topic.buyerProblem}
+Recommended product/page: ${topic.product}
+Required internal link: ${topic.internalLink}
+Audience: ${topic.audience}
+
+Hard rules:
+- Mention ONLY real Nature's Way Soil products or pages named here: Dog Urine Neutralizer & Lawn Repair, Liquid Lawn Soil Conditioner, Liquid Biochar, Liquid Humic & Fulvic Acid with Kelp, Hay/Pasture/Lawn Recovery System, Living Soil Revitalizer, government grounds quote page, shop page.
+- Do NOT invent products such as turning forks, compost bins, soil test kits, potting mixes, organic mulch, or tools.
+- No guaranteed results, no pesticide claims, no disease/cure claims.
+- Include a short answer in the first 120 words.
+- Include practical steps the reader can use today.
+- Include a section titled exactly: Recommended Nature's Way Soil Product
+- Include this exact markdown link once: [View the recommended Nature's Way Soil solution](${topic.internalLink})
+- End with a clear CTA to shop or request a quote at natureswaysoil.com.
+- 900 to 1200 words. Use markdown headings.
+
+Return JSON only:
+{
+  "title": "SEO title, 50-65 characters",
+  "excerpt": "150-160 character summary",
+  "content": "full markdown article",
+  "category": "${topic.category}",
+  "tags": ${JSON.stringify(topic.tags)},
+  "seoKeywords": ["${topic.targetKeyword}", "${topic.product}"],
+  "videoPrompt": "15-25 second visual prompt for a short social video"
+}`
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: process.env.OPENAI_BLOG_MODEL || 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content: 'You write useful, specific, buyer-intent lawn, garden, pasture, and soil-health content for Nature\'s Way Soil. Return valid JSON only.'
+        },
+        { role: 'user', content: prompt }
+      ],
+      temperature: 0.35,
+      max_tokens: 4200,
+      response_format: { type: 'json_object' }
+    })
+
+    const raw = response.choices?.[0]?.message?.content || ''
+    const blogData = extractJson(raw)
+    const title = String(blogData.title || fallbackArticle(topic).title)
+    const slug = slugify(title)
+
+    const blogPost: BlogPost = {
+      title,
+      slug,
+      excerpt: String(blogData.excerpt || '').slice(0, 180) || fallbackArticle(topic).excerpt,
+      content: String(blogData.content || fallbackArticle(topic).content),
+      category: String(blogData.category || topic.category),
+      tags: Array.isArray(blogData.tags) ? blogData.tags.map(String) : topic.tags,
+      videoPrompt: String(blogData.videoPrompt || topic.visualPrompt),
+      seoKeywords: Array.isArray(blogData.seoKeywords) ? blogData.seoKeywords.map(String) : [topic.targetKeyword, topic.product, ...topic.tags],
+      publishDate: new Date().toISOString(),
+    }
+
+    console.log('✅ Blog article generated successfully!')
+    console.log(`   Title: ${blogPost.title}`)
+    console.log(`   Word Count: ~${blogPost.content.split(/\s+/).length} words`)
+    console.log(`   Tags: ${blogPost.tags.join(', ')}`)
+    return blogPost
+  } catch (error: any) {
+    console.error('❌ Failed to generate blog article, using fallback:', error.message)
+    return fallbackArticle(topic)
+  }
+}
+
+/**
+ * Generate video for the blog post using HeyGen.
+ * No fake default avatar is used. Set HEYGEN_DEFAULT_AVATAR and HEYGEN_DEFAULT_VOICE to valid IDs from the HeyGen account.
  */
 export async function generateBlogVideo(blogPost: BlogPost): Promise<string | null> {
   console.log(`\n🎬 Generating video for: ${blogPost.title}`)
-  
+
   if (!process.env.HEYGEN_API_KEY && !process.env.GCP_SECRET_HEYGEN_API_KEY) {
     console.log('⚠️  HeyGen API key not configured, skipping video generation')
     return null
   }
 
-  try {
-    // Create a compelling video script from the blog content
-    const videoScript = `${blogPost.videoPrompt}. Professional, cinematic style. Nature, garden, soil close-ups. Vibrant green plants. Healthy soil texture.`
+  const avatar = process.env.HEYGEN_DEFAULT_AVATAR
+  const voice = process.env.HEYGEN_DEFAULT_VOICE
 
-    console.log('Creating HeyGen video job...')
-    
-    // Initialize HeyGen client with secrets support
+  if (!avatar || !voice) {
+    console.log('⚠️  Missing valid HEYGEN_DEFAULT_AVATAR or HEYGEN_DEFAULT_VOICE; skipping video so the run can still publish/link-post the blog')
+    return null
+  }
+
+  try {
+    const videoScript = `${blogPost.videoPrompt}. Use a warm helpful farming and garden tone. Show Nature's Way Soil style product and soil close-ups. End with: Read the full guide at natureswaysoil.com/blog/${blogPost.slug}.`
     const heygen = await createClientWithSecrets()
-    
-    // Get avatar and voice settings with fallback defaults
-    const avatar = process.env.HEYGEN_DEFAULT_AVATAR || 'garden_expert_01'
-    const voice = process.env.HEYGEN_DEFAULT_VOICE || 'en_us_warm_female_01'
     const lengthSeconds = parseInt(process.env.HEYGEN_VIDEO_DURATION_SECONDS || '30')
-    
-    // Create video generation job
+
     const jobId = await heygen.createVideoJob({
       script: videoScript,
       title: blogPost.title,
       lengthSeconds,
       avatar,
       voice,
-      music: {
-        style: 'nature',
-        volume: 0.15
-      },
-      subtitles: {
-        enabled: true,
-        style: 'modern'
-      },
+      music: { style: 'nature', volume: 0.15 },
+      subtitles: { enabled: true, style: 'modern' },
       webhook: process.env.HEYGEN_WEBHOOK_URL,
-      meta: {
-        blogSlug: blogPost.slug,
-        category: blogPost.category
-      }
+      meta: { blogSlug: blogPost.slug, category: blogPost.category }
     })
 
     console.log(`✅ HeyGen job created: ${jobId}`)
-    console.log('⏳ Waiting for video to be ready...')
-
-    // Poll for completion (timeout 20 minutes)
     const videoUrl = await heygen.pollJobForVideoUrl(jobId, {
       timeoutMs: 20 * 60_000,
       intervalMs: 10_000
     })
-    
+
     if (videoUrl) {
       console.log(`✅ Video ready: ${videoUrl}`)
       return videoUrl
-    } else {
-      console.log('⚠️  Video generation timed out or failed')
-      return null
     }
+
+    console.log('⚠️  Video generation timed out or failed')
+    return null
   } catch (error: any) {
-    console.error('❌ Video generation failed:', error.message)
+    const details = error?.response?.data || error?.message || String(error)
+    console.error('❌ Video generation failed:', details)
+    console.error('   Check HEYGEN_DEFAULT_AVATAR and HEYGEN_DEFAULT_VOICE; the old hard-coded garden_expert_01 value was removed.')
     return null
   }
 }
 
-/**
- * Save blog post to Supabase or file system
- */
+/** Save blog post to Supabase or file system. */
 export async function saveBlogPost(blogPost: BlogPost, videoUrl: string | null) {
   console.log(`\n💾 Saving blog post: ${blogPost.slug}`)
-  
-  // Try to save to Supabase first
+
   try {
     const { createClient } = await import('@supabase/supabase-js')
     const supabase = createClient(
@@ -234,219 +348,154 @@ export async function saveBlogPost(blogPost: BlogPost, videoUrl: string | null) 
       .select()
 
     if (error) throw error
-
     console.log('✅ Blog post saved to database')
     console.log(`   URL: https://natureswaysoil.com/blog/${blogPost.slug}`)
-    
     return data
   } catch (error: any) {
-    console.log('⚠️  Database save failed, saving to file instead')
-    
-    // Fallback: Save to file system
+    console.log('⚠️  Database save failed, saving to file instead:', error?.message || String(error))
     const fs = await import('fs')
     const path = await import('path')
-    
     const blogDir = path.join(process.cwd(), 'generated-blogs')
-    if (!fs.existsSync(blogDir)) {
-      fs.mkdirSync(blogDir, { recursive: true })
-    }
-
-    const blogData = {
-      ...blogPost,
-      videoUrl,
-      generatedAt: new Date().toISOString()
-    }
-
+    if (!fs.existsSync(blogDir)) fs.mkdirSync(blogDir, { recursive: true })
+    const blogData = { ...blogPost, videoUrl, generatedAt: new Date().toISOString() }
     const filename = path.join(blogDir, `${blogPost.slug}.json`)
     fs.writeFileSync(filename, JSON.stringify(blogData, null, 2))
-    
     console.log(`✅ Blog post saved to file: ${filename}`)
-    
     return blogData
   }
 }
 
-/**
- * Post video to social media platforms
- */
+function socialCaption(blogPost: BlogPost): string {
+  return `${blogPost.title}\n\n${blogPost.excerpt}\n\nRead the full guide: https://natureswaysoil.com/blog/${blogPost.slug}\n\n#soilhealth #lawncare #organicgardening #natureswaysoil`
+}
+
+/** Post video to social media platforms. */
 export async function postBlogVideoToSocial(blogPost: BlogPost, videoUrl: string) {
   console.log('\n📱 Posting video to social media...')
-  
-  const caption = `${blogPost.title}\n\n${blogPost.excerpt}\n\nRead more: https://natureswaysoil.com/blog/${blogPost.slug}\n\n#organicgardening #soilhealth #naturalgardening`
-  
+  const caption = socialCaption(blogPost)
   const results: any = {}
-  
-  // YouTube (caption used as title, first 5000 chars of content as description)
+
   if (process.env.YT_CLIENT_ID && process.env.YT_CLIENT_SECRET && process.env.YT_REFRESH_TOKEN) {
     try {
       console.log('📺 Uploading to YouTube...')
-      const ytVideoId = await postToYouTube(
-        videoUrl,
-        blogPost.title,
-        process.env.YT_CLIENT_ID,
-        process.env.YT_CLIENT_SECRET,
-        process.env.YT_REFRESH_TOKEN,
-        (process.env.YT_PRIVACY_STATUS as 'public' | 'unlisted' | 'private') || 'public'
-      )
-      console.log('✅ Posted to YouTube:', ytVideoId)
+      const ytVideoId = await postToYouTube(videoUrl, blogPost.title, process.env.YT_CLIENT_ID, process.env.YT_CLIENT_SECRET, process.env.YT_REFRESH_TOKEN, (process.env.YT_PRIVACY_STATUS as 'public' | 'unlisted' | 'private') || 'public')
       results.youtube = { success: true, videoId: ytVideoId }
+      console.log('✅ Posted to YouTube:', ytVideoId)
     } catch (error: any) {
-      console.error('❌ YouTube upload failed:', error.message)
       results.youtube = { success: false, error: error.message }
+      console.error('❌ YouTube upload failed:', error.message)
     }
   } else {
     console.log('⏭️  Skipping YouTube - credentials not configured')
   }
-  
-  // Instagram
+
   if (process.env.INSTAGRAM_ACCESS_TOKEN && process.env.INSTAGRAM_IG_ID) {
     try {
       console.log('📸 Posting to Instagram...')
-      const igResult = await postToInstagram(
-        videoUrl,
-        caption,
-        process.env.INSTAGRAM_ACCESS_TOKEN,
-        process.env.INSTAGRAM_IG_ID
-      )
-      console.log('✅ Posted to Instagram:', igResult || 'success')
+      const igResult = await postToInstagram(videoUrl, caption, process.env.INSTAGRAM_ACCESS_TOKEN, process.env.INSTAGRAM_IG_ID)
       results.instagram = { success: true, mediaId: igResult }
+      console.log('✅ Posted to Instagram:', igResult || 'success')
     } catch (error: any) {
-      console.error('❌ Instagram post failed:', error.message)
       results.instagram = { success: false, error: error.message }
+      console.error('❌ Instagram post failed:', error.message)
     }
   } else {
     console.log('⏭️  Skipping Instagram - credentials not configured')
   }
-  
-  // Twitter
+
   if (process.env.TWITTER_BEARER_TOKEN) {
     try {
-      console.log('🐦 Posting to Twitter...')
+      console.log('🐦 Posting to Twitter/X...')
       await postToTwitter(videoUrl, caption, process.env.TWITTER_BEARER_TOKEN)
-      console.log('✅ Posted to Twitter')
       results.twitter = { success: true }
+      console.log('✅ Posted to Twitter/X')
     } catch (error: any) {
-      console.error('❌ Twitter post failed:', error.message)
       results.twitter = { success: false, error: error.message }
+      console.error('❌ Twitter/X post failed:', error.message)
     }
   } else {
-    console.log('⏭️  Skipping Twitter - credentials not configured')
+    console.log('⏭️  Skipping Twitter/X - credentials not configured')
   }
-  
-  // Pinterest (requires board ID)
+
   if (process.env.PINTEREST_ACCESS_TOKEN && process.env.PINTEREST_BOARD_ID) {
     try {
       console.log('📌 Posting to Pinterest...')
-      await postToPinterest(
-        videoUrl,
-        caption,
-        process.env.PINTEREST_ACCESS_TOKEN,
-        process.env.PINTEREST_BOARD_ID
-      )
-      console.log('✅ Posted to Pinterest')
+      await postToPinterest(videoUrl, caption, process.env.PINTEREST_ACCESS_TOKEN, process.env.PINTEREST_BOARD_ID)
       results.pinterest = { success: true }
+      console.log('✅ Posted to Pinterest')
     } catch (error: any) {
-      console.error('❌ Pinterest post failed:', error.message)
       results.pinterest = { success: false, error: error.message }
+      console.error('❌ Pinterest post failed:', error.message)
     }
   } else {
-    console.log('⏭️  Skipping Pinterest - board ID not configured')
+    console.log('⏭️  Skipping Pinterest - credentials not configured')
   }
 
-  // Facebook
   if (process.env.FACEBOOK_PAGE_ACCESS_TOKEN && process.env.FACEBOOK_PAGE_ID) {
     try {
-      console.log('👤 Posting to Facebook...')
-      const fbRes = await axios.post(
-        `https://graph.facebook.com/v19.0/${process.env.FACEBOOK_PAGE_ID}/videos`,
-        {
-          file_url: videoUrl,
-          description: caption,
-          access_token: process.env.FACEBOOK_PAGE_ACCESS_TOKEN,
-        }
-      )
-      console.log('✅ Posted to Facebook:', fbRes.data?.id)
+      console.log('👤 Posting video to Facebook...')
+      const fbRes = await axios.post(`https://graph.facebook.com/v19.0/${process.env.FACEBOOK_PAGE_ID}/videos`, {
+        file_url: videoUrl,
+        description: caption,
+        access_token: process.env.FACEBOOK_PAGE_ACCESS_TOKEN,
+      })
       results.facebook = { success: true, postId: fbRes.data?.id }
+      console.log('✅ Posted to Facebook:', fbRes.data?.id)
     } catch (error: any) {
-      console.error('❌ Facebook post failed:', error?.response?.data || error.message)
       results.facebook = { success: false, error: error.message }
+      console.error('❌ Facebook video post failed:', error?.response?.data || error.message)
     }
   } else {
     console.log('⏭️  Skipping Facebook - credentials not configured')
   }
 
-  // LinkedIn
   if (process.env.LINKEDIN_ACCESS_TOKEN && process.env.LINKEDIN_PERSON_ID) {
     try {
-      console.log('💼 Posting to LinkedIn...')
-      const liRes = await axios.post(
-        'https://api.linkedin.com/v2/ugcPosts',
-        {
-          author: `urn:li:person:${process.env.LINKEDIN_PERSON_ID}`,
-          lifecycleState: 'PUBLISHED',
-          specificContent: {
-            'com.linkedin.ugc.ShareContent': {
-              shareCommentary: { text: caption },
-              shareMediaCategory: 'VIDEO',
-              media: [{
-                status: 'READY',
-                description: { text: blogPost.excerpt.substring(0, 200) },
-                media: videoUrl,
-                title: { text: blogPost.title },
-              }],
-            },
+      console.log('💼 Posting video to LinkedIn...')
+      const liRes = await axios.post('https://api.linkedin.com/v2/ugcPosts', {
+        author: `urn:li:person:${process.env.LINKEDIN_PERSON_ID}`,
+        lifecycleState: 'PUBLISHED',
+        specificContent: {
+          'com.linkedin.ugc.ShareContent': {
+            shareCommentary: { text: caption },
+            shareMediaCategory: 'VIDEO',
+            media: [{ status: 'READY', description: { text: blogPost.excerpt.substring(0, 200) }, media: videoUrl, title: { text: blogPost.title } }],
           },
-          visibility: { 'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC' },
         },
-        {
-          headers: {
-            Authorization: `Bearer ${process.env.LINKEDIN_ACCESS_TOKEN}`,
-            'Content-Type': 'application/json',
-            'X-Restli-Protocol-Version': '2.0.0',
-          },
-        }
-      )
-      console.log('✅ Posted to LinkedIn:', liRes.data?.id)
+        visibility: { 'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC' },
+      }, {
+        headers: { Authorization: `Bearer ${process.env.LINKEDIN_ACCESS_TOKEN}`, 'Content-Type': 'application/json', 'X-Restli-Protocol-Version': '2.0.0' },
+      })
       results.linkedin = { success: true, postId: liRes.data?.id }
+      console.log('✅ Posted to LinkedIn:', liRes.data?.id)
     } catch (error: any) {
-      console.error('❌ LinkedIn post failed:', error?.response?.data || error.message)
       results.linkedin = { success: false, error: error.message }
+      console.error('❌ LinkedIn video post failed:', error?.response?.data || error.message)
     }
   } else {
     console.log('⏭️  Skipping LinkedIn - credentials not configured')
   }
 
-  // TikTok
   if (process.env.TIKTOK_ACCESS_TOKEN) {
     try {
       console.log('🎵 Posting to TikTok...')
-      const ttRes = await axios.post(
-        'https://open.tiktokapis.com/v2/post/publish/video/init/',
-        {
-          post_info: {
-            title: blogPost.title.substring(0, 150),
-            privacy_level: process.env.TIKTOK_PRIVACY_LEVEL || 'PUBLIC_TO_EVERYONE',
-            disable_duet: false,
-            disable_comment: false,
-            disable_stitch: false,
-          },
-          source_info: {
-            source: 'PULL_FROM_URL',
-            video_url: videoUrl,
-          },
+      const ttRes = await axios.post('https://open.tiktokapis.com/v2/post/publish/video/init/', {
+        post_info: {
+          title: blogPost.title.substring(0, 150),
+          privacy_level: process.env.TIKTOK_PRIVACY_LEVEL || 'PUBLIC_TO_EVERYONE',
+          disable_duet: false,
+          disable_comment: false,
+          disable_stitch: false,
         },
-        {
-          headers: {
-            Authorization: `Bearer ${process.env.TIKTOK_ACCESS_TOKEN}`,
-            'Content-Type': 'application/json; charset=UTF-8',
-          },
-        }
-      )
-      console.log('✅ Posted to TikTok, publish_id:', ttRes.data?.data?.publish_id)
+        source_info: { source: 'PULL_FROM_URL', video_url: videoUrl },
+      }, {
+        headers: { Authorization: `Bearer ${process.env.TIKTOK_ACCESS_TOKEN}`, 'Content-Type': 'application/json; charset=UTF-8' },
+      })
       results.tiktok = { success: true, publishId: ttRes.data?.data?.publish_id }
+      console.log('✅ Posted to TikTok, publish_id:', ttRes.data?.data?.publish_id)
     } catch (error: any) {
-      console.error('❌ TikTok post failed:', error?.response?.data || error.message)
       results.tiktok = { success: false, error: error.message }
+      console.error('❌ TikTok post failed:', error?.response?.data || error.message)
     }
   } else {
     console.log('⏭️  Skipping TikTok - access token not configured')
@@ -455,21 +504,78 @@ export async function postBlogVideoToSocial(blogPost: BlogPost, videoUrl: string
   return results
 }
 
-/**
- * Publish the blog post to the Nature's Way Soil website by committing it
- * to public/blog_articles.json on the configured GitHub repo.
- *
- * Gated by ENABLE_BLOG_POSTING=true and a valid GITHUB_TOKEN.
- * Defaults: repo=natureswaysoil/best, branch=main.
- */
-export async function publishBlogToGitHub(
-  blogPost: BlogPost,
-  videoUrl: string | null
-): Promise<{ success: boolean; commitSha?: string; skipped?: boolean; reason?: string; error?: string }> {
+/** Post blog link when video is unavailable, so traffic does not stop just because HeyGen fails. */
+export async function postBlogLinkToSocial(blogPost: BlogPost) {
+  console.log('\n📣 Posting blog link to social media because no video was generated...')
+  const caption = socialCaption(blogPost)
+  const blogUrl = `https://natureswaysoil.com/blog/${blogPost.slug}`
+  const results: any = {}
+
+  if (process.env.TWITTER_BEARER_TOKEN) {
+    try {
+      const res = await axios.post('https://api.twitter.com/2/tweets', { text: caption.substring(0, 275) }, {
+        headers: { Authorization: `Bearer ${process.env.TWITTER_BEARER_TOKEN}` }
+      })
+      results.twitter = { success: true, postId: res.data?.data?.id }
+      console.log('✅ Posted blog link to Twitter/X')
+    } catch (error: any) {
+      results.twitter = { success: false, error: error.message }
+      console.error('❌ Twitter/X link post failed:', error?.response?.data || error.message)
+    }
+  }
+
+  if (process.env.FACEBOOK_PAGE_ACCESS_TOKEN && process.env.FACEBOOK_PAGE_ID) {
+    try {
+      const fbRes = await axios.post(`https://graph.facebook.com/v19.0/${process.env.FACEBOOK_PAGE_ID}/feed`, {
+        message: caption,
+        link: blogUrl,
+        access_token: process.env.FACEBOOK_PAGE_ACCESS_TOKEN,
+      })
+      results.facebook = { success: true, postId: fbRes.data?.id }
+      console.log('✅ Posted blog link to Facebook')
+    } catch (error: any) {
+      results.facebook = { success: false, error: error.message }
+      console.error('❌ Facebook link post failed:', error?.response?.data || error.message)
+    }
+  }
+
+  if (process.env.LINKEDIN_ACCESS_TOKEN && process.env.LINKEDIN_PERSON_ID) {
+    try {
+      const liRes = await axios.post('https://api.linkedin.com/v2/ugcPosts', {
+        author: `urn:li:person:${process.env.LINKEDIN_PERSON_ID}`,
+        lifecycleState: 'PUBLISHED',
+        specificContent: {
+          'com.linkedin.ugc.ShareContent': {
+            shareCommentary: { text: `${caption}\n${blogUrl}` },
+            shareMediaCategory: 'NONE',
+          },
+        },
+        visibility: { 'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC' },
+      }, {
+        headers: { Authorization: `Bearer ${process.env.LINKEDIN_ACCESS_TOKEN}`, 'Content-Type': 'application/json', 'X-Restli-Protocol-Version': '2.0.0' },
+      })
+      results.linkedin = { success: true, postId: liRes.data?.id }
+      console.log('✅ Posted blog link to LinkedIn')
+    } catch (error: any) {
+      results.linkedin = { success: false, error: error.message }
+      console.error('❌ LinkedIn link post failed:', error?.response?.data || error.message)
+    }
+  }
+
+  if (!Object.keys(results).length) {
+    console.log('⏭️  No text/link social credentials configured')
+  }
+
+  return results
+}
+
+/** Publish the blog post to the Nature's Way Soil website by committing it to public/blog_articles.json. */
+export async function publishBlogToGitHub(blogPost: BlogPost, videoUrl: string | null): Promise<{ success: boolean; commitSha?: string; skipped?: boolean; reason?: string; error?: string }> {
   if (process.env.ENABLE_BLOG_POSTING !== 'true') {
     console.log('⏭️  Skipping GitHub blog publish - ENABLE_BLOG_POSTING is not true')
     return { success: false, skipped: true, reason: 'ENABLE_BLOG_POSTING!=true' }
   }
+
   const githubToken = process.env.GITHUB_TOKEN
   if (!githubToken) {
     console.log('⏭️  Skipping GitHub blog publish - GITHUB_TOKEN not set')
@@ -483,27 +589,18 @@ export async function publishBlogToGitHub(
 
   try {
     console.log(`\n📰 Publishing blog to GitHub: ${repo}@${branch}:${filePath}`)
-
-    // Fetch current articles file
-    const fileResponse = await axios.get(fileUrl, {
-      headers: {
-        Authorization: `Bearer ${githubToken}`,
-        Accept: 'application/vnd.github.v3+json',
-      },
-    })
-
+    const fileResponse = await axios.get(fileUrl, { headers: { Authorization: `Bearer ${githubToken}`, Accept: 'application/vnd.github.v3+json' } })
     const currentContent = Buffer.from(fileResponse.data.content, 'base64').toString('utf-8')
     const currentArticles: any[] = JSON.parse(currentContent)
 
-    // Skip if a post with the same title or slug already exists
     const existingSlugs = new Set(currentArticles.map((a: any) => a.slug))
     const existingTitles = new Set(currentArticles.map((a: any) => String(a.title || '').toLowerCase()))
     if (existingTitles.has(blogPost.title.toLowerCase())) {
       console.log(`⚠️  Blog article "${blogPost.title}" already exists on GitHub - skipping duplicate`)
       return { success: true, skipped: true, reason: 'duplicate-title' }
     }
-    const slug = existingSlugs.has(blogPost.slug) ? `${blogPost.slug}-${Date.now()}` : blogPost.slug
 
+    const slug = existingSlugs.has(blogPost.slug) ? `${blogPost.slug}-${Date.now()}` : blogPost.slug
     const newArticle = {
       id: `article_${Date.now()}`,
       slug,
@@ -521,25 +618,14 @@ export async function publishBlogToGitHub(
       seoKeywords: blogPost.seoKeywords || [],
     }
 
-    // Prepend so newest appears first
     currentArticles.unshift(newArticle)
-
     const updatedContent = JSON.stringify(currentArticles, null, 2)
-    const updateResponse = await axios.put(
-      fileUrl,
-      {
-        message: `Add blog article: ${newArticle.title}`,
-        content: Buffer.from(updatedContent).toString('base64'),
-        sha: fileResponse.data.sha,
-        branch,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${githubToken}`,
-          Accept: 'application/vnd.github.v3+json',
-        },
-      }
-    )
+    const updateResponse = await axios.put(fileUrl, {
+      message: `Add blog article: ${newArticle.title}`,
+      content: Buffer.from(updatedContent).toString('base64'),
+      sha: fileResponse.data.sha,
+      branch,
+    }, { headers: { Authorization: `Bearer ${githubToken}`, Accept: 'application/vnd.github.v3+json' } })
 
     const commitSha = updateResponse.data?.commit?.sha
     console.log('✅ Blog published to GitHub')
@@ -554,36 +640,28 @@ export async function publishBlogToGitHub(
   }
 }
 
-/**
- * Main execution function
- */
+/** Main execution function. */
 export async function runBlogGeneration() {
   console.log('\n' + '='.repeat(60))
   console.log('🚀 AUTOMATED BLOG & VIDEO GENERATION')
   console.log('='.repeat(60))
   console.log(`Started at: ${new Date().toISOString()}`)
-  
-  try {
-    // Step 1: Generate blog article
-    const blogPost = await generateBlogArticle()
-    
-    // Step 2: Generate video
-    const videoUrl = await generateBlogVideo(blogPost)
-    
-    // Step 3: Save blog post
-    await saveBlogPost(blogPost, videoUrl)
 
-    // Step 4: Publish blog to website via GitHub (gated by ENABLE_BLOG_POSTING)
+  try {
+    const blogPost = await generateBlogArticle()
+    const videoUrl = await generateBlogVideo(blogPost)
+    await saveBlogPost(blogPost, videoUrl)
     const githubResult = await publishBlogToGitHub(blogPost, videoUrl)
 
-    // Step 5: Post to social media (if video was generated)
     let socialResults: any = {}
     if (videoUrl) {
       socialResults = await postBlogVideoToSocial(blogPost, videoUrl)
+    } else if (githubResult.success && !githubResult.skipped) {
+      socialResults = await postBlogLinkToSocial(blogPost)
     } else {
-      console.log('\n⏭️  Skipping social media posting - no video generated')
+      console.log('\n⏭️  Skipping social media posting - no video generated and blog was not newly published')
     }
-    
+
     console.log('\n' + '='.repeat(60))
     console.log('✅ Blog generation completed successfully!')
     console.log('='.repeat(60))
@@ -591,16 +669,15 @@ export async function runBlogGeneration() {
     console.log(`Slug: ${blogPost.slug}`)
     console.log(`Video: ${videoUrl || 'Not generated'}`)
     console.log(`GitHub Blog: ${githubResult.success ? (githubResult.skipped ? '⏭️  skipped (' + githubResult.reason + ')' : '✅ ' + (githubResult.commitSha || 'committed')) : '❌ ' + (githubResult.error || 'failed')}`)
-    console.log(`Social Media:`)
-    console.log(`  YouTube:   ${socialResults.youtube?.success   ? '✅' : socialResults.youtube   ? '❌' : '⏭️  skipped'}`)
+    console.log('Social Media:')
+    console.log(`  YouTube:   ${socialResults.youtube?.success ? '✅' : socialResults.youtube ? '❌' : '⏭️  skipped'}`)
     console.log(`  Instagram: ${socialResults.instagram?.success ? '✅' : socialResults.instagram ? '❌' : '⏭️  skipped'}`)
-    console.log(`  Twitter:   ${socialResults.twitter?.success   ? '✅' : socialResults.twitter   ? '❌' : '⏭️  skipped'}`)
+    console.log(`  Twitter:   ${socialResults.twitter?.success ? '✅' : socialResults.twitter ? '❌' : '⏭️  skipped'}`)
     console.log(`  Pinterest: ${socialResults.pinterest?.success ? '✅' : socialResults.pinterest ? '❌' : '⏭️  skipped'}`)
-    console.log(`  Facebook:  ${socialResults.facebook?.success  ? '✅' : socialResults.facebook  ? '❌' : '⏭️  skipped'}`)
-    console.log(`  LinkedIn:  ${socialResults.linkedin?.success  ? '✅' : socialResults.linkedin  ? '❌' : '⏭️  skipped'}`)
-    console.log(`  TikTok:    ${socialResults.tiktok?.success    ? '✅' : socialResults.tiktok    ? '❌' : '⏭️  skipped'}`)
+    console.log(`  Facebook:  ${socialResults.facebook?.success ? '✅' : socialResults.facebook ? '❌' : '⏭️  skipped'}`)
+    console.log(`  LinkedIn:  ${socialResults.linkedin?.success ? '✅' : socialResults.linkedin ? '❌' : '⏭️  skipped'}`)
+    console.log(`  TikTok:    ${socialResults.tiktok?.success ? '✅' : socialResults.tiktok ? '❌' : '⏭️  skipped'}`)
     console.log('='.repeat(60) + '\n')
-    
   } catch (error: any) {
     const message = error?.message || String(error)
     console.error('\n❌ Blog generation failed:', message)
@@ -608,13 +685,14 @@ export async function runBlogGeneration() {
   }
 }
 
-// Run if executed directly
 if (require.main === module) {
-  runBlogGeneration().then(() => {
-    console.log('✅ Done')
-    process.exit(0)
-  }).catch((error) => {
-    console.error('❌ Fatal error:', error)
-    process.exit(1)
-  })
+  runBlogGeneration()
+    .then(() => {
+      console.log('✅ Done')
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error('❌ Fatal error:', error)
+      process.exit(1)
+    })
 }

--- a/src/heygen.ts
+++ b/src/heygen.ts
@@ -1,291 +1,264 @@
 // src/heygen.ts
-// Compatibility module for the blog generator.
-// The old blog code imports './heygen'. This restores that import and turns it
-// into an OpenAI-powered blog package generator instead of a dead HeyGen call.
+// Lightweight HeyGen client used by the scheduled blog/video generator.
 
-import * as fs from 'fs'
-import * as path from 'path'
-import OpenAI from 'openai'
+import axios, { AxiosInstance } from 'axios'
 
-export type BlogVideoInput = {
+type CreateVideoPayload = {
+  script: string
   title?: string
-  productName?: string
-  productTitle?: string
-  product?: any
-  keywords?: string[] | string
-  benefits?: string[] | string
-  targetAudience?: string
-  category?: string
-  landingPageUrl?: string
-  websiteUrl?: string
-  script?: string
-  voiceover?: string
-  brollQueries?: string[]
-  [key: string]: any
+  lengthSeconds?: number
+  avatar?: string
+  voice?: string
+  imageUrl?: string
+  scenes?: Array<{
+    avatarText?: string
+    brollUrl?: string
+  }>
+  music?: any
+  subtitles?: any
+  webhook?: string
+  meta?: Record<string, any>
 }
 
-export type BlogVideoResult = {
-  videoUrl: string
-  videoId: string
-  status: string
-  provider: string
-  skipped?: boolean
-  message?: string
-  script?: string
-  blogTitle?: string
-  metaDescription?: string
-  slug?: string
-  markdown?: string
-  brollQueries?: string[]
-  ctaUrl?: string
+type JobStatus = {
+  jobId: string
+  status: 'pending' | 'processing' | 'completed' | 'failed'
+  videoUrl?: string
+  error?: string
 }
 
-function asList(value: string[] | string | undefined): string[] {
-  if (Array.isArray(value)) return value.map(String).map((v) => v.trim()).filter(Boolean)
-  return String(value || '')
-    .split(/[,\n;|]+/g)
-    .map((v) => v.trim())
-    .filter(Boolean)
+type PollOptions = {
+  timeoutMs?: number
+  intervalMs?: number
+  initialDelayMs?: number
+  notFoundGracePeriodMs?: number
 }
 
-function slugify(value: string): string {
-  return String(value || 'nature-way-soil-blog')
-    .toLowerCase()
-    .replace(/&/g, ' and ')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 80) || 'nature-way-soil-blog'
-}
-
-function productName(input: BlogVideoInput): string {
+function isPlaceholderApiKey(value: string | undefined): boolean {
+  const normalized = String(value || '').trim().toLowerCase()
   return (
-    input.productName ||
-    input.productTitle ||
-    input.title ||
-    input.product?.name ||
-    input.product?.title ||
-    input.product?.Title ||
-    'Nature’s Way Soil product'
+    !normalized ||
+    normalized.includes('your-') ||
+    normalized.includes('paste_') ||
+    normalized.includes('replace_') ||
+    normalized === 'changeme'
   )
 }
 
-function ctaUrl(input: BlogVideoInput): string {
-  const url =
-    input.landingPageUrl ||
-    input.websiteUrl ||
-    input.product?.landingPageUrl ||
-    input.product?.websiteUrl ||
-    input.product?.Landing_Page_URL ||
-    input.product?.Website_URL ||
-    ''
-
-  if (/^https?:\/\//i.test(String(url))) return String(url)
-  if (String(url).startsWith('/')) return `https://www.natureswaysoil.com${url}`
-  return 'https://www.natureswaysoil.com/'
-}
-
-function buildFallbackBroll(input: BlogVideoInput): string[] {
-  const name = productName(input)
-  const category = input.category || input.product?.category || input.product?.Category || ''
-  const keywords = asList(input.keywords || input.product?.keywords || input.product?.Keywords)
-  const benefits = asList(input.benefits || input.product?.benefits || input.product?.Benefits)
-  const text = `${name} ${category} ${keywords.join(' ')} ${benefits.join(' ')}`.toLowerCase()
-
-  if (/dog|urine|pet|odor|yellow spot/.test(text)) {
-    return ['dog on green lawn', 'yellow lawn spots grass', 'homeowner spraying lawn', 'healthy green turf close up', 'garden hose sprayer lawn']
-  }
-
-  if (/pasture|hay|field|farm|acre|horse|cattle/.test(text)) {
-    return ['farmer pasture field', 'hay field grass', 'tractor spraying pasture', 'healthy pasture close up', 'farm soil grass roots']
-  }
-
-  if (/tomato|vegetable|pepper|fruit|berry|flower|bloom/.test(text)) {
-    return ['vegetable garden tomatoes', 'gardener watering tomato plants', 'raised bed garden soil', 'healthy vegetable plants close up', 'garden harvest vegetables']
-  }
-
-  if (/orchid|house plant|indoor/.test(text)) {
-    return ['gardener caring for potted plants', 'orchid plant close up', 'potting soil indoor plants', 'houseplant watering', 'healthy roots potting mix']
-  }
-
-  if (/biochar|charcoal|compost|worm|casting|soil|humic|fulvic|kelp/.test(text)) {
-    return ['hands holding rich soil', 'garden compost soil close up', 'biochar soil amendment', 'raised bed garden soil', 'healthy garden plants']
-  }
-
-  return ['organic garden soil', 'gardener spraying plants', 'healthy garden plants', 'soil close up roots', 'farm garden rows']
-}
-
-function fallbackBlog(input: BlogVideoInput): BlogVideoResult {
-  const name = productName(input)
-  const url = ctaUrl(input)
-  const keywords = asList(input.keywords || input.product?.keywords || input.product?.Keywords)
-  const benefits = asList(input.benefits || input.product?.benefits || input.product?.Benefits)
-  const slug = slugify(name)
-  const brollQueries = input.brollQueries?.length ? input.brollQueries : buildFallbackBroll(input)
-
-  const blogTitle = `How ${name} Supports Healthier Soil and Stronger Plants`
-  const metaDescription = `${name} from Nature’s Way Soil helps support practical lawn, garden, and soil care. Learn how to use it and when it fits your routine.`.slice(0, 155)
-
-  const script = [
-    `Hook: If your lawn, garden, or soil is not responding the way it should, the problem may start below the surface.`,
-    `Problem: Weak roots, tired soil, poor drainage, and low soil activity can hold plants back.`,
-    `Solution: ${name} is designed as a practical soil-first product for regular lawn, garden, farm, or plant-care use.`,
-    benefits.length ? `Key benefits: ${benefits.slice(0, 4).join(', ')}.` : '',
-    `CTA: Learn more at ${url}.`
-  ].filter(Boolean).join(' ')
-
-  const markdown = `---
-title: "${blogTitle.replace(/"/g, '\\"')}"
-description: "${metaDescription.replace(/"/g, '\\"')}"
-slug: "${slug}"
----
-
-# ${blogTitle}
-
-If your lawn, garden, pasture, or potted plants are not responding the way they should, the problem often starts in the soil. Soil structure, root-zone activity, moisture movement, and nutrient availability all affect how well plants can grow.
-
-## The problem this product helps address
-
-${name} is a Nature’s Way Soil product built for practical soil and plant care. It fits homeowners, gardeners, landowners, and growers who want a simple way to support healthier soil routines.
-
-${keywords.length ? `Common related topics include: ${keywords.slice(0, 10).join(', ')}.` : ''}
-
-## How ${name} fits into a soil-care routine
-
-Use ${name} as part of a regular lawn, garden, pasture, or plant-care program according to the label directions. It is meant to support the soil environment around the root zone rather than act like a quick cosmetic cover-up.
-
-${benefits.length ? `Key benefits listed for this product include ${benefits.slice(0, 5).join(', ')}.` : ''}
-
-## Best visual scenes for a short video
-
-${brollQueries.map((query) => `- ${query}`).join('\n')}
-
-## Learn more
-
-See product details and application guidance here:
-
-[Visit Nature’s Way Soil](${url})
-`
-
-  return {
-    videoUrl: '',
-    videoId: '',
-    status: 'blog_ready_video_not_generated_here',
-    provider: 'openai-blog-compatibility',
-    skipped: true,
-    message: 'Blog package generated. Video posting is handled by the scheduled social video pipeline.',
-    script,
-    blogTitle,
-    metaDescription,
-    slug,
-    markdown,
-    brollQueries,
-    ctaUrl: url
-  }
-}
-
-async function generateOpenAIBlog(input: BlogVideoInput): Promise<BlogVideoResult> {
-  if (!process.env.OPENAI_API_KEY) return fallbackBlog(input)
-
-  const name = productName(input)
-  const url = ctaUrl(input)
-  const keywords = asList(input.keywords || input.product?.keywords || input.product?.Keywords)
-  const benefits = asList(input.benefits || input.product?.benefits || input.product?.Benefits)
-  const brollQueries = input.brollQueries?.length ? input.brollQueries : buildFallbackBroll(input)
-
-  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-  const prompt = `Create a traffic-driving blog package for Nature's Way Soil.
-
-Product: ${name}
-Category: ${input.category || input.product?.category || input.product?.Category || ''}
-Keywords: ${keywords.join(', ')}
-Benefits: ${benefits.join(', ')}
-Target audience: ${input.targetAudience || input.product?.targetAudience || input.product?.Target_Audience || 'homeowners, gardeners, lawn care customers, farmers, and homesteaders'}
-CTA URL: ${url}
-B-roll ideas: ${brollQueries.join(', ')}
-
-Return JSON only with:
-{
-  "blogTitle": "...",
-  "metaDescription": "...",
-  "slug": "...",
-  "script": "25-35 second video script with hook, problem, solution, CTA",
-  "markdown": "complete SEO blog post in Markdown with H1, H2 sections, internal CTA link, and practical product use guidance"
-}
-
-Rules:
-- Plainspoken and helpful.
-- No guaranteed results.
-- No pesticide, disease, or cure claims.
-- Keep it farm, lawn, garden, pasture, soil, compost, roots, watering, or sprayer related.
-- CTA should point to the product landing page if available, otherwise natureswaysoil.com.`
-
+async function getSecretFromGcp(name: string): Promise<string | null> {
   try {
-    const response = await client.chat.completions.create({
-      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
-      messages: [{ role: 'user', content: prompt }],
-      temperature: 0.25,
-      max_tokens: 1400
+    // Keep this dynamic import so local development does not require GCP auth.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { SecretManagerServiceClient } = require('@google-cloud/secret-manager')
+    const client = new SecretManagerServiceClient()
+    const [accessResponse] = await client.accessSecretVersion({ name })
+    return accessResponse.payload?.data?.toString('utf8') || null
+  } catch (error: any) {
+    console.warn('Could not load HeyGen secret from GCP:', error?.message || error)
+    return null
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export class HeyGenClient {
+  private readonly apiKey: string
+  private readonly apiEndpoint: string
+  private readonly axios: AxiosInstance
+  private readonly avatarCache: Record<string, string> = {}
+  private readonly voiceCache: Record<string, string> = {}
+
+  constructor(cfg: { apiKey?: string; apiEndpoint?: string } = {}) {
+    this.apiKey = cfg.apiKey || process.env.HEYGEN_API_KEY || ''
+    this.apiEndpoint = cfg.apiEndpoint || process.env.HEYGEN_API_ENDPOINT || 'https://api.heygen.com'
+
+    if (isPlaceholderApiKey(this.apiKey)) {
+      throw new Error('HeyGen API key is missing or still set to a placeholder.')
+    }
+
+    this.axios = axios.create({
+      baseURL: this.apiEndpoint,
+      timeout: Number(process.env.TIMEOUT_HEYGEN || 60_000),
+      headers: {
+        'X-Api-Key': this.apiKey,
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  async resolveAvatarId(nameOrId: string): Promise<string> {
+    if (!nameOrId) return nameOrId
+    if (this.avatarCache[nameOrId]) return this.avatarCache[nameOrId]
+
+    try {
+      const res = await this.axios.get('/v2/avatars', { timeout: 30_000 })
+      const avatars = res.data?.data?.avatars || res.data?.avatars || []
+      const lowered = nameOrId.toLowerCase()
+      const match =
+        avatars.find((a: any) => a.avatar_id === nameOrId) ||
+        avatars.find((a: any) => String(a.avatar_name || '').toLowerCase() === lowered) ||
+        avatars.find((a: any) => String(a.avatar_name || '').toLowerCase().includes(lowered))
+
+      for (const avatar of avatars) {
+        if (avatar?.avatar_id) {
+          this.avatarCache[avatar.avatar_id] = avatar.avatar_id
+          if (avatar.avatar_name) this.avatarCache[avatar.avatar_name] = avatar.avatar_id
+        }
+      }
+
+      return match?.avatar_id || nameOrId
+    } catch (error: any) {
+      console.warn('Could not list HeyGen avatars:', error?.response?.data || error?.message || error)
+      return nameOrId
+    }
+  }
+
+  async resolveVoiceId(nameOrId: string): Promise<string> {
+    if (!nameOrId) return nameOrId
+    if (this.voiceCache[nameOrId]) return this.voiceCache[nameOrId]
+
+    try {
+      const res = await this.axios.get('/v2/voices', { timeout: 30_000 })
+      const voices = res.data?.data?.voices || res.data?.voices || []
+      const lowered = nameOrId.toLowerCase()
+      const match =
+        voices.find((v: any) => v.voice_id === nameOrId) ||
+        voices.find((v: any) => String(v.name || '').toLowerCase() === lowered) ||
+        voices.find((v: any) => String(v.name || '').toLowerCase().includes(lowered))
+
+      for (const voice of voices) {
+        if (voice?.voice_id) {
+          this.voiceCache[voice.voice_id] = voice.voice_id
+          if (voice.name) this.voiceCache[voice.name] = voice.voice_id
+        }
+      }
+
+      return match?.voice_id || nameOrId
+    } catch (error: any) {
+      console.warn('Could not list HeyGen voices:', error?.response?.data || error?.message || error)
+      return nameOrId
+    }
+  }
+
+  async createVideoJob(payload: CreateVideoPayload): Promise<string> {
+    if (!payload.script) throw new Error('Script is required for HeyGen video generation')
+
+    const resolvedAvatarId = await this.resolveAvatarId(payload.avatar || process.env.HEYGEN_DEFAULT_AVATAR || '')
+    const resolvedVoiceId = await this.resolveVoiceId(payload.voice || process.env.HEYGEN_DEFAULT_VOICE || '')
+
+    if (!resolvedAvatarId || !resolvedVoiceId) {
+      throw new Error('Missing HEYGEN_DEFAULT_AVATAR or HEYGEN_DEFAULT_VOICE')
+    }
+
+    const videoInputs = payload.scenes?.length
+      ? payload.scenes.map(scene => ({
+          character: {
+            type: 'avatar',
+            avatar_id: resolvedAvatarId,
+            avatar_style: 'normal',
+          },
+          voice: {
+            type: 'text',
+            input_text: scene.avatarText || payload.script,
+            voice_id: resolvedVoiceId,
+            speed: 1.0,
+          },
+          background: scene.brollUrl
+            ? { type: 'video', url: scene.brollUrl }
+            : payload.imageUrl
+              ? { type: 'image', url: payload.imageUrl }
+              : { type: 'color', value: '#1a3a1a' },
+        }))
+      : [
+          {
+            character: {
+              type: 'avatar',
+              avatar_id: resolvedAvatarId,
+              avatar_style: 'normal',
+            },
+            voice: {
+              type: 'text',
+              input_text: payload.script,
+              voice_id: resolvedVoiceId,
+              speed: 1.0,
+            },
+            background: payload.imageUrl
+              ? { type: 'image', url: payload.imageUrl }
+              : { type: 'color', value: '#1a3a1a' },
+          },
+        ]
+
+    const body = {
+      video_inputs: videoInputs,
+      dimension: { width: 720, height: 1280 },
+      ...(payload.title ? { title: payload.title } : {}),
+      ...(payload.webhook ? { callback_url: payload.webhook } : {}),
+    }
+
+    const response = await this.axios.post('/v2/video/generate', body, {
+      timeout: Number(process.env.TIMEOUT_HEYGEN || 60_000),
     })
 
-    const text = response.choices[0]?.message?.content?.trim() || ''
-    const match = text.match(/\{[\s\S]*\}/)
-    const parsed = match ? JSON.parse(match[0]) : null
-    const fallback = fallbackBlog(input)
+    const jobId = response.data?.data?.video_id || response.data?.video_id || response.data?.jobId
+    if (!jobId) {
+      throw new Error(`HeyGen API did not return a video job ID: ${JSON.stringify(response.data)}`)
+    }
+
+    return String(jobId)
+  }
+
+  async getJobStatus(jobId: string): Promise<JobStatus> {
+    const response = await this.axios.get(`/v1/video_status.get?video_id=${encodeURIComponent(jobId)}`, {
+      timeout: Number(process.env.TIMEOUT_HEYGEN || 60_000),
+    })
+    const data = response.data?.data || response.data || {}
 
     return {
-      ...fallback,
-      blogTitle: parsed?.blogTitle || fallback.blogTitle,
-      metaDescription: parsed?.metaDescription || fallback.metaDescription,
-      slug: parsed?.slug || fallback.slug,
-      script: parsed?.script || fallback.script,
-      markdown: parsed?.markdown || fallback.markdown,
-      status: 'blog_ready',
-      skipped: false
+      jobId,
+      status: this.normalizeStatus(data?.status),
+      videoUrl: data?.video_url || data?.videoUrl || data?.url,
+      error: data?.error || data?.error_message,
     }
-  } catch (error: any) {
-    const fallback = fallbackBlog(input)
-    return {
-      ...fallback,
-      message: `OpenAI blog generation failed, fallback blog returned: ${error?.message || error}`
+  }
+
+  async pollJobForVideoUrl(jobId: string, opts: PollOptions = {}): Promise<string> {
+    const startedAt = Date.now()
+    const timeoutMs = opts.timeoutMs ?? 20 * 60_000
+    const intervalMs = opts.intervalMs ?? 15_000
+    const initialDelayMs = opts.initialDelayMs ?? 0
+
+    if (initialDelayMs > 0) await sleep(initialDelayMs)
+
+    while (Date.now() - startedAt < timeoutMs) {
+      const result = await this.getJobStatus(jobId)
+      if (result.status === 'completed' && result.videoUrl) return result.videoUrl
+      if (result.status === 'failed') throw new Error(`HeyGen job failed: ${result.error || 'unknown error'}`)
+      await sleep(intervalMs)
     }
+
+    throw new Error('HeyGen job timed out')
+  }
+
+  private normalizeStatus(status: string): JobStatus['status'] {
+    const s = String(status || '').toLowerCase()
+    if (s.includes('complet') || s === 'success') return 'completed'
+    if (s.includes('fail') || s === 'error') return 'failed'
+    if (s.includes('process') || s === 'running') return 'processing'
+    return 'pending'
   }
 }
 
-// Old names that blog-generator.ts may import.
-export async function generateHeyGenVideo(input: BlogVideoInput): Promise<BlogVideoResult> {
-  return generateOpenAIBlog(input)
+export async function createClientWithSecrets(): Promise<HeyGenClient> {
+  let apiKey = process.env.HEYGEN_API_KEY
+
+  if (!apiKey && process.env.GCP_SECRET_HEYGEN_API_KEY) {
+    const secret = await getSecretFromGcp(process.env.GCP_SECRET_HEYGEN_API_KEY)
+    if (secret) apiKey = secret
+  }
+
+  return new HeyGenClient({ apiKey: apiKey || undefined })
 }
 
-export async function createHeyGenVideo(input: BlogVideoInput): Promise<BlogVideoResult> {
-  return generateOpenAIBlog(input)
-}
-
-export async function createVideo(input: BlogVideoInput): Promise<BlogVideoResult> {
-  return generateOpenAIBlog(input)
-}
-
-export async function generateBlogVideo(input: BlogVideoInput): Promise<BlogVideoResult> {
-  return generateOpenAIBlog(input)
-}
-
-export async function generateBlogPackage(input: BlogVideoInput): Promise<BlogVideoResult> {
-  return generateOpenAIBlog(input)
-}
-
-export function saveBlogMarkdown(result: BlogVideoResult, outputDir = 'content/blog') {
-  const slug = result.slug || slugify(result.blogTitle || 'nature-way-soil-blog')
-  const dir = path.resolve(process.cwd(), outputDir)
-  fs.mkdirSync(dir, { recursive: true })
-  const file = path.resolve(dir, `${slug}.md`)
-  fs.writeFileSync(file, result.markdown || '', 'utf8')
-  return file
-}
-
-export default {
-  generateHeyGenVideo,
-  createHeyGenVideo,
-  createVideo,
-  generateBlogVideo,
-  generateBlogPackage,
-  saveBlogMarkdown
-}
+export default HeyGenClient

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -14,10 +14,109 @@ const rateLimiters = getRateLimiters()
 // Maximum video size for Twitter (500MB)
 const MAX_VIDEO_SIZE_MB = 500
 
+function twitterText(caption: string, url?: string): string {
+  const base = String(caption || '').trim()
+  const link = String(url || '').trim()
+  const text = link && !base.includes(link) ? `${base}\n${link}` : base
+  return text.slice(0, 275)
+}
+
+function hasOAuth1TwitterCreds(): boolean {
+  return Boolean(
+    process.env.TWITTER_API_KEY &&
+      process.env.TWITTER_API_SECRET &&
+      process.env.TWITTER_ACCESS_TOKEN &&
+      process.env.TWITTER_ACCESS_SECRET
+  )
+}
+
+async function postTextWithOAuth1(text: string): Promise<string> {
+  const client = new TwitterApi({
+    appKey: process.env.TWITTER_API_KEY as string,
+    appSecret: process.env.TWITTER_API_SECRET as string,
+    accessToken: process.env.TWITTER_ACCESS_TOKEN as string,
+    accessSecret: process.env.TWITTER_ACCESS_SECRET as string,
+  })
+
+  const result = await client.readWrite.v2.tweet(text.slice(0, 275))
+  return result.data.id
+}
+
+/** Posts a text/link-only tweet. Prefer OAuth 1.0a user context because app-only bearer auth cannot post. */
+export async function postTextToTwitter(text: string, bearerToken?: string): Promise<string> {
+  const config = getConfig()
+  const safeText = twitterText(text)
+
+  if (!safeText) {
+    throw new AppError('Missing text for Twitter post', ErrorCode.VALIDATION_ERROR, 400, true)
+  }
+
+  if (hasOAuth1TwitterCreds()) {
+    return rateLimiters.execute('twitter', async () => {
+      return withRetry(
+        async () => postTextWithOAuth1(safeText),
+        {
+          maxRetries: 2,
+          retryIf: (error) => {
+            const s = (error as any)?.response?.status ?? (error as any)?.data?.status ?? (error as any)?.code
+            if (s === 401 || s === 402 || s === 403) return false
+            return true
+          },
+          onRetry: (error, attempt) => {
+            logger.warn('Retrying Twitter text post', 'Twitter', {
+              attempt,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          },
+        }
+      )
+    })
+  }
+
+  if (!bearerToken) {
+    throw new AppError(
+      'Twitter OAuth 1.0a credentials missing and bearer token not provided',
+      ErrorCode.MISSING_CONFIG,
+      500
+    )
+  }
+
+  return rateLimiters.execute('twitter', async () => {
+    return withRetry(
+      async () => {
+        const res = await axios.post(
+          'https://api.twitter.com/2/tweets',
+          { text: safeText },
+          {
+            headers: { Authorization: `Bearer ${bearerToken}` },
+            timeout: config.TIMEOUT_SOCIAL_POST,
+          }
+        )
+        return String(res.data?.data?.id ?? '')
+      },
+      {
+        maxRetries: 2,
+        retryIf: (error) => {
+          // 403 = app-only bearer token cannot write tweets; retrying always fails.
+          const s = (error as any)?.response?.status ?? (error as any)?.data?.status
+          if (s === 401 || s === 402 || s === 403) return false
+          return true
+        },
+        onRetry: (error, attempt) => {
+          logger.warn('Retrying Twitter bearer text post', 'Twitter', {
+            attempt,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        },
+      }
+    )
+  })
+}
+
 /**
  * Posts to Twitter/X.
- * If OAuth 1.0a credentials are present (env), uploads the video and posts a tweet with the media.
- * Otherwise, falls back to a simple text tweet (caption + URL) using Bearer token.
+ * If OAuth 1.0a credentials are present, tries to upload the video and post a media tweet.
+ * If X blocks the media upload/API tier, falls back to a normal text/link tweet so traffic does not stop.
  */
 export async function postToTwitter(
   videoUrl: string,
@@ -39,12 +138,7 @@ export async function postToTwitter(
       )
     }
 
-    const canUpload = Boolean(
-      process.env.TWITTER_API_KEY &&
-        process.env.TWITTER_API_SECRET &&
-        process.env.TWITTER_ACCESS_TOKEN &&
-        process.env.TWITTER_ACCESS_SECRET
-    )
+    const canUpload = hasOAuth1TwitterCreds()
 
     logger.info('Posting to Twitter', 'Twitter', {
       canUpload,
@@ -65,72 +159,84 @@ export async function postToTwitter(
             })
             const rwClient = client.readWrite
 
-            // Check memory before downloading video
-            const memoryBefore = getMemoryUsage()
-            logger.debug('Memory before video download', 'Twitter', {
-              heapUsedMB: memoryBefore.heapUsedMB,
-            })
-
-            // Check video size before downloading
             try {
-              const headResponse = await axios.head(videoUrl)
-              const contentLength = parseInt(String(headResponse.headers['content-length'] || '0'), 10)
-              const sizeMB = contentLength / (1024 * 1024)
+              // Check memory before downloading video
+              const memoryBefore = getMemoryUsage()
+              logger.debug('Memory before video download', 'Twitter', {
+                heapUsedMB: memoryBefore.heapUsedMB,
+              })
 
-              if (sizeMB > MAX_VIDEO_SIZE_MB) {
-                throw new AppError(
-                  `Video too large for Twitter: ${sizeMB.toFixed(2)}MB (max ${MAX_VIDEO_SIZE_MB}MB)`,
-                  ErrorCode.VALIDATION_ERROR,
-                  400,
-                  true,
-                  { videoSizeMB: sizeMB, maxSizeMB: MAX_VIDEO_SIZE_MB }
-                )
+              // Check video size before downloading
+              try {
+                const headResponse = await axios.head(videoUrl)
+                const contentLength = parseInt(String(headResponse.headers['content-length'] || '0'), 10)
+                const sizeMB = contentLength / (1024 * 1024)
+
+                if (sizeMB > MAX_VIDEO_SIZE_MB) {
+                  throw new AppError(
+                    `Video too large for Twitter: ${sizeMB.toFixed(2)}MB (max ${MAX_VIDEO_SIZE_MB}MB)`,
+                    ErrorCode.VALIDATION_ERROR,
+                    400,
+                    true,
+                    { videoSizeMB: sizeMB, maxSizeMB: MAX_VIDEO_SIZE_MB }
+                  )
+                }
+
+                logger.debug('Video size check', 'Twitter', { sizeMB: sizeMB.toFixed(2) })
+              } catch (error) {
+                // If HEAD request fails, continue anyway (some servers don't support HEAD)
+                logger.warn('Could not check video size', 'Twitter', {}, error)
               }
 
-              logger.debug('Video size check', 'Twitter', { sizeMB: sizeMB.toFixed(2) })
-            } catch (error) {
-              // If HEAD request fails, continue anyway (some servers don't support HEAD)
-              logger.warn('Could not check video size', 'Twitter', {}, error)
+              // Download the video file into memory for upload
+              logger.debug('Downloading video for Twitter upload', 'Twitter')
+              const resp = await axios.get<ArrayBuffer>(videoUrl, {
+                responseType: 'arraybuffer',
+                timeout: config.TIMEOUT_SOCIAL_POST,
+                maxContentLength: MAX_VIDEO_SIZE_MB * 1024 * 1024,
+              })
+
+              const memoryAfter = getMemoryUsage()
+              const memoryUsedMB = memoryAfter.heapUsedMB - memoryBefore.heapUsedMB
+              logger.debug('Video downloaded', 'Twitter', {
+                heapUsedMB: memoryAfter.heapUsedMB,
+                memoryUsedForVideoMB: memoryUsedMB,
+              })
+
+              // Upload media
+              logger.debug('Uploading video to Twitter', 'Twitter')
+              const mediaId = await rwClient.v1.uploadMedia(Buffer.from(resp.data), {
+                mimeType: 'video/mp4',
+              } as any)
+
+              // Post tweet with media
+              logger.debug('Posting tweet with media', 'Twitter')
+              const tweetResult = await rwClient.v2.tweet({
+                text: caption,
+                media: { media_ids: [mediaId] },
+              })
+
+              logger.debug('Tweet posted successfully with media', 'Twitter')
+              return tweetResult.data.id
+            } catch (mediaError: any) {
+              const status = mediaError?.response?.status ?? mediaError?.data?.status ?? mediaError?.code
+              logger.warn('Twitter video upload failed; falling back to text/link tweet', 'Twitter', {
+                status,
+                message: mediaError?.message || String(mediaError),
+              })
+
+              const fallbackText = twitterText(caption, videoUrl)
+              const textResult = await rwClient.v2.tweet(fallbackText)
+              logger.info('Posted Twitter fallback text/link tweet', 'Twitter')
+              return textResult.data.id
             }
-
-            // Download the video file into memory for upload
-            logger.debug('Downloading video for Twitter upload', 'Twitter')
-            const resp = await axios.get<ArrayBuffer>(videoUrl, {
-              responseType: 'arraybuffer',
-              timeout: config.TIMEOUT_SOCIAL_POST,
-              maxContentLength: MAX_VIDEO_SIZE_MB * 1024 * 1024,
-            })
-
-            const memoryAfter = getMemoryUsage()
-            const memoryUsedMB = memoryAfter.heapUsedMB - memoryBefore.heapUsedMB
-            logger.debug('Video downloaded', 'Twitter', {
-              heapUsedMB: memoryAfter.heapUsedMB,
-              memoryUsedForVideoMB: memoryUsedMB,
-            })
-
-            // Upload media
-            logger.debug('Uploading video to Twitter', 'Twitter')
-            const mediaId = await rwClient.v1.uploadMedia(Buffer.from(resp.data), {
-              type: 'video/mp4',
-            })
-
-            // Post tweet with media
-            logger.debug('Posting tweet', 'Twitter')
-            const tweetResult = await rwClient.v2.tweet({
-              text: caption,
-              media: { media_ids: [mediaId] },
-            })
-
-            logger.debug('Tweet posted successfully', 'Twitter')
-            return tweetResult.data.id
           },
           {
-            maxRetries: 3,
+            maxRetries: 2,
             retryIf: (error) => {
               if (error instanceof AppError && error.code === ErrorCode.VALIDATION_ERROR) return false
-              // 403 = API tier blocks video upload — retrying always fails
               const s = (error as any)?.response?.status ?? (error as any)?.data?.status
-              if (s === 403) return false
+              if (s === 401 || s === 402 || s === 403) return false
               return true
             },
             onRetry: (error, attempt) => {
@@ -143,45 +249,8 @@ export async function postToTwitter(
         )
       })
     } else {
-      // Fallback to bearer token (text only)
-      if (!bearerToken) {
-        throw new AppError(
-          'Twitter bearer token missing and upload credentials not provided',
-          ErrorCode.MISSING_CONFIG,
-          500
-        )
-      }
-
-      postId = await rateLimiters.execute('twitter', async () => {
-        return withRetry(
-          async () => {
-            const res = await axios.post(
-              'https://api.twitter.com/2/tweets',
-              { text: `${caption}\n${videoUrl}` },
-              {
-                headers: { Authorization: `Bearer ${bearerToken}` },
-                timeout: config.TIMEOUT_SOCIAL_POST,
-              }
-            )
-            return String(res.data?.data?.id ?? '')
-          },
-          {
-            maxRetries: 3,
-            retryIf: (error) => {
-              // 403 = bearer token lacks write permission — never retryable
-              const s = (error as any)?.response?.status ?? (error as any)?.data?.status
-              if (s === 403) return false
-              return true
-            },
-            onRetry: (error, attempt) => {
-              logger.warn('Retrying Twitter text post', 'Twitter', {
-                attempt,
-                error: error instanceof Error ? error.message : String(error),
-              })
-            },
-          }
-        )
-      })
+      // Fallback to text-only post. Bearer app-only auth normally cannot write tweets, but keep this for older configs.
+      postId = await postTextToTwitter(twitterText(caption, videoUrl), bearerToken)
     }
 
     const duration = Date.now() - startTime


### PR DESCRIPTION
## What changed

- Replaced broad blog topics with buyer-intent Nature's Way Soil topics tied to real products and landing pages.
- Added prompt rules so generated blogs do not invent products such as tools, bins, soil test kits, potting mixes, or mulch.
- Removed the hard-coded `garden_expert_01` HeyGen fallback that caused the avatar lookup failure.
- Requires valid `HEYGEN_DEFAULT_AVATAR` and `HEYGEN_DEFAULT_VOICE` environment variables before trying HeyGen.
- Adds a blog-link social fallback for Twitter/X, Facebook, and LinkedIn when no video is available, so traffic posting is not blocked by video generation.
- Preserves GitHub blog publishing to `natureswaysoil/best:public/blog_articles.json`.

## Why

The scheduled run published the blog, but video generation failed because the configured avatar was not found. Since the old workflow only posted to social media when a video existed, all social posting was skipped.

## Follow-up after merge

- Set `HEYGEN_DEFAULT_AVATAR` to a valid HeyGen avatar ID.
- Set `HEYGEN_DEFAULT_VOICE` to a valid HeyGen voice ID.
- Rotate any credential that may have appeared in logs or shared screenshots.