### PR TITLE
Harden Twitter campaign posting

### DIFF
--- a/.github/workflows/video-automation.yml
+++ b/.github/workflows/video-automation.yml
@@ -80,6 +80,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify Twitter retry policy
+        run: npm run test:twitter-policy
+
+      - name: Type-check campaign code
+        run: npm run typecheck
+
       - name: Verify bundled test campaign videos exist
         run: |
           test -d "$TEST_VIDEOS_DIR"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "validate": "ts-node scripts/validate-system.ts",
     "test:csv": "ts-node scripts/test-csv-processing.ts",
     "test:openai": "ts-node scripts/test-openai-script.ts",
+    "test:twitter-policy": "ts-node scripts/test-twitter-policy.ts",
     "test:heygen": "ts-node scripts/test-heygen-integration.ts",
     "test:platforms": "ts-node scripts/test-all-platforms.ts",
     "test:e2e": "ts-node scripts/test-e2e-integration.ts",

--- a/scripts/run-test-video-campaign.ts
+++ b/scripts/run-test-video-campaign.ts
@@ -43,8 +43,6 @@ const TEST_CAMPAIGN_SECRET_NAMES = [
   // Instagram / Meta
   'INSTAGRAM_ACCESS_TOKEN',
   'INSTAGRAM_IG_ID',
-  'INSTAGRAM_USER_ID',
-  'INSTAGRAM_ACCOUNT_ID',
   'FACEBOOK_ACCESS_TOKEN',
   'FACEBOOK_PAGE_ID',
 
@@ -56,20 +54,13 @@ const TEST_CAMPAIGN_SECRET_NAMES = [
   'YOUTUBE_CLIENT_ID',
   'YOUTUBE_CLIENT_SECRET',
   'YOUTUBE_REFRESH_TOKEN',
-  'YOUTUBE_OAUTH_REFRESH_TOKEN',
   'YT_CLIENT_ID',
   'YT_CLIENT_SECRET',
   'YT_REFRESH_TOKEN',
-  'CLIENT_ID',
-  'CLIENT_SECRET',
-  'REFRESH_TOKEN',
 
   // Supabase Storage (for hosting local videos when TEST_VIDEO_PUBLIC_BASE_URL is not set)
   'NEXT_PUBLIC_SUPABASE_URL',
-  'SUPABASE_URL',
   'SUPABASE_SERVICE_ROLE_KEY',
-  'SUPABASE_SERVICE_KEY',
-  'SUPABASE_VIDEO_BUCKET',
 ]
 
 async function loadCampaignSecretsFromGoogleSecretManager(): Promise<void> {
@@ -357,14 +348,21 @@ async function main(): Promise<void> {
   }
 
   if (isPlatformEnabled('twitter', enabledPlatforms) || isPlatformEnabled('x', enabledPlatforms)) {
-    const tw = await postToTwitter(videoUrl, caption)
-    anySucceeded = true
-    console.log('âœ… Posted to Twitter', tw)
+    try {
+      const tw = await postToTwitter(videoUrl, caption)
+      anySucceeded = true
+      console.log('âœ… Posted to Twitter', tw)
+    } catch (error: any) {
+      console.error(
+        'Twitter/X posting failed; continuing any other enabled platforms:',
+        error?.message || error
+      )
+    }
   }
 
   if (!anySucceeded) {
     throw new Error(
-      'No enabled platform had valid credentials. Configure ENABLE_PLATFORMS for instagram/pinterest/youtube and ensure required secrets exist in Google Secret Manager. Twitter/X is disabled.'
+      'No enabled platform completed successfully. Check ENABLE_PLATFORMS, credentials, and the platform errors above.'
     )
   }
 

--- a/scripts/test-twitter-policy.ts
+++ b/scripts/test-twitter-policy.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import {
+  getTwitterErrorStatus,
+  isRetryableTwitterError,
+} from '../src/twitter'
+
+const paymentRequired = {
+  code: 402,
+  data: {
+    status: 402,
+    detail: 'credits depleted',
+  },
+}
+
+assert.equal(getTwitterErrorStatus(paymentRequired), 402)
+assert.equal(isRetryableTwitterError(paymentRequired), false)
+assert.equal(isRetryableTwitterError({ response: { status: 400 } }), false)
+assert.equal(isRetryableTwitterError({ response: { status: 401 } }), false)
+assert.equal(isRetryableTwitterError({ response: { status: 403 } }), false)
+assert.equal(isRetryableTwitterError({ response: { status: 429 } }), true)
+assert.equal(isRetryableTwitterError({ response: { status: 500 } }), true)
+assert.equal(isRetryableTwitterError(new Error('socket disconnected')), true)
+
+console.log('Twitter retry policy tests passed')

--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -14,6 +14,26 @@ const rateLimiters = getRateLimiters()
 // Maximum video size for Twitter (500MB)
 const MAX_VIDEO_SIZE_MB = 500
 
+export function getTwitterErrorStatus(error: unknown): number | undefined {
+  const candidate =
+    (error as any)?.response?.status ??
+    (error as any)?.data?.status ??
+    (error as any)?.code
+  const status = Number(candidate)
+  return Number.isFinite(status) ? status : undefined
+}
+
+export function isRetryableTwitterError(error: unknown): boolean {
+  if (error instanceof AppError && error.code === ErrorCode.VALIDATION_ERROR) {
+    return false
+  }
+
+  const status = getTwitterErrorStatus(error)
+  if (status === undefined) return true
+  if (status === 429) return true
+  return status >= 500
+}
+
 /**
  * Posts to Twitter/X.
  * If OAuth 1.0a credentials are present (env), uploads the video and posts a tweet with the media.
@@ -111,7 +131,7 @@ export async function postToTwitter(
             // Upload media
             logger.debug('Uploading video to Twitter', 'Twitter')
             const mediaId = await rwClient.v1.uploadMedia(Buffer.from(resp.data), {
-              type: 'video/mp4',
+              mimeType: 'video/mp4',
             })
 
             // Post tweet with media
@@ -126,13 +146,7 @@ export async function postToTwitter(
           },
           {
             maxRetries: 3,
-            retryIf: (error) => {
-              if (error instanceof AppError && error.code === ErrorCode.VALIDATION_ERROR) return false
-              // 403 = API tier blocks video upload — retrying always fails
-              const s = (error as any)?.response?.status ?? (error as any)?.data?.status
-              if (s === 403) return false
-              return true
-            },
+            retryIf: isRetryableTwitterError,
             onRetry: (error, attempt) => {
               logger.warn('Retrying Twitter post', 'Twitter', {
                 attempt,
@@ -167,12 +181,7 @@ export async function postToTwitter(
           },
           {
             maxRetries: 3,
-            retryIf: (error) => {
-              // 403 = bearer token lacks write permission — never retryable
-              const s = (error as any)?.response?.status ?? (error as any)?.data?.status
-              if (s === 403) return false
-              return true
-            },
+            retryIf: isRetryableTwitterError,
             onRetry: (error, attempt) => {
               logger.warn('Retrying Twitter text post', 'Twitter', {
                 attempt,


### PR DESCRIPTION
## What changed

- replace deprecated Twitter media upload `type` with `mimeType`
- classify Twitter API failures by status
- stop retrying permanent `400`, `401`, `402`, and `403` responses
- continue other enabled platforms when Twitter fails
- still fail a Twitter-only campaign when no platform succeeds
- remove redundant Secret Manager alias requests that produced false missing-secret warnings
- add a focused Twitter retry-policy test
- run the policy test and TypeScript typecheck before the scheduled paid post

## Root cause

The scheduled Twitter-only campaign received HTTP 402 (`credits depleted`). The retry callback treated nearly every API error as retryable, so the workflow retried the permanent billing failure three times and then exited. The uploader also used a deprecated `type` option.

## Validation

- `npm run test:twitter-policy` — passed
- `npm run typecheck` — passed
- `npm run build` — passed
- source diff check — passed

General local environment validation reports missing `CSV_URL` and HeyGen credentials because the isolated checkout intentionally has no production secrets. The GitHub workflow loads its credentials from Google Secret Manager.

## Operational note

Twitter credits have now been replenished. No live campaign was triggered from this PR, avoiding an unintended duplicate post.