### PR TITLE
Fix sheet-row dependency installation

### DIFF
--- a/.github/workflows/sheet-row-posting.yml
+++ b/.github/workflows/sheet-row-posting.yml
@@ -86,7 +86,9 @@ jobs:
           sudo apt-get install -y ffmpeg
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          npm ci
+          test -f node_modules/gaxios/build/cjs/src/index.js
 
       - name: Run Google Sheet row post
         run: npm run post:sheet-row


### PR DESCRIPTION
## What changed

- replace the sheet-row workflow's incremental `npm install` with deterministic `npm ci`
- verify the required `gaxios` CommonJS entry point exists before starting the posting script

## Root cause

The repository contains historically tracked `node_modules` files, including an incomplete `gaxios` package. Incremental installation treated that package as present even though `build/cjs/src/index.js` was missing.

## Impact

The Google Sheet row posting workflow now starts from the lockfile-defined dependency tree and fails during installation with a clear integrity check if `gaxios` is incomplete.

## Validation

- `npm ci`
- `require('gaxios')`
- `npm run typecheck`
- `npm run build`
