### PR TITLE
Restore scheduled B-roll posting pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",
+        "@google-cloud/storage": "^7.21.0",
         "@supabase/supabase-js": "^2.45.4",
         "@types/node-cache": "^4.1.3",
         "axios": "^1.7.7",
@@ -48,6 +49,37 @@
         "node": ">=12"
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@google-cloud/secret-manager": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.1.1.tgz",
@@ -58,6 +90,188 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -125,6 +339,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -257,6 +483,15 @@
         "@supabase/storage-js": "2.75.0"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -290,6 +525,12 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -385,6 +626,35 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
     },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
@@ -414,6 +684,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -530,6 +806,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -540,6 +828,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1075,6 +1381,45 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -1421,6 +1766,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1447,15 +1841,32 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -1538,6 +1949,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -1809,12 +2244,42 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1968,6 +2433,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/retry-request": {
@@ -2197,6 +2671,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -2355,6 +2844,20 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -2434,6 +2937,21 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -2477,6 +2995,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@google-cloud/secret-manager": "^6.1.1",
+    "@google-cloud/storage": "^7.21.0",
     "@supabase/supabase-js": "^2.45.4",
     "@types/node-cache": "^4.1.3",
     "axios": "^1.7.7",

--- a/scripts/lib/caption-formatter.ts
+++ b/scripts/lib/caption-formatter.ts
@@ -1,0 +1,52 @@
+export type CaptionPlatform = 'youtube' | 'instagram' | 'facebook' | 'tiktok' | 'facebook_groups'
+
+const SITE_URL = 'https://www.natureswaysoil.com'
+
+function clamp(text: string, max: number) {
+  return String(text || '').slice(0, max)
+}
+
+function hashtags(platform: CaptionPlatform) {
+  if (platform === 'instagram') {
+    return [
+      '#NaturesWaySoil', '#SoilHealth', '#LawnCare', '#GardenTips', '#PastureCare',
+      '#OrganicGardening', '#Homesteading', '#RegenerativeAgriculture', '#HealthySoil', '#LawnRepair',
+      '#GardenSoil', '#RootHealth', '#PlantCare', '#BackyardGarden', '#SoilBiology',
+      '#GrassCare', '#TurfCare', '#GardenLife', '#FarmLife', '#Compost', '#Biochar',
+      '#HumicAcid', '#FulvicAcid', '#Kelp', '#SoilFirst'
+    ]
+  }
+  if (platform === 'tiktok') return ['#NaturesWaySoil', '#LawnCare', '#SoilHealth', '#GardenTips', '#PastureCare']
+  if (platform === 'youtube') return ['#NaturesWaySoil', '#SoilHealth', '#LawnCare', '#Gardening', '#PastureCare']
+  return ['#NaturesWaySoil', '#SoilHealth', '#LawnCare', '#Gardening']
+}
+
+function siteCta() {
+  return `Learn more: ${SITE_URL}`
+}
+
+export function formatCaption(product: any, scenePlan: any, platform: CaptionPlatform) {
+  const title = String(product?.name || '').trim()
+  const description = String(product?.description || '').trim()
+  const hook = String(scenePlan?.scenes?.[0]?.voiceover || scenePlan?.scenes?.[0]?.caption || '').trim()
+  const tags = hashtags(platform).join(' ')
+
+  if (platform === 'youtube') {
+    const lines = [title, description, siteCta(), tags]
+    return clamp(lines.filter(Boolean).join('\n\n'), 5000)
+  }
+
+  if (platform === 'instagram') {
+    const lines = [title, hook || description, siteCta(), tags]
+    return clamp(lines.filter(Boolean).join('\n\n'), 2200)
+  }
+
+  if (platform === 'tiktok') {
+    const firstLine = hook || `Soil-first support with ${title}`
+    const lines = [`${firstLine}\n${siteCta()}`, description, tags]
+    return clamp(lines.filter(Boolean).join('\n\n'), 2200)
+  }
+
+  const lines = [title, description, `See full details at ${SITE_URL}.`, tags]
+  return clamp(lines.filter(Boolean).join('\n\n'), 63206)
+}

--- a/scripts/lib/facebook-groups.ts
+++ b/scripts/lib/facebook-groups.ts
@@ -1,0 +1,72 @@
+import fs from 'fs'
+import path from 'path'
+import axios from 'axios'
+
+const ROOT = process.cwd()
+const GROUPS_CONFIG = path.resolve(ROOT, 'config/facebook-groups.json')
+
+function readJson(file: string, fallback: any) {
+  try {
+    if (!fs.existsSync(file)) return fallback
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+function inferTopics(product: any): string[] {
+  const text = `${product?.name || ''} ${product?.category || ''} ${(product?.keywords || []).join(' ')}`.toLowerCase()
+  const topics = new Set<string>()
+  if (/pasture|hay|field|farm|horse|cattle/.test(text)) topics.add('pasture')
+  if (/garden|compost|worm|biochar|vegetable|flower|plant/.test(text)) topics.add('garden')
+  if (/lawn|grass|turf|dog|urine|humic|fulvic|kelp/.test(text)) topics.add('lawn')
+  if (!topics.size) topics.add('lawn')
+  return Array.from(topics)
+}
+
+export async function postToFacebookGroup(groupId: string, publicVideoUrl: string, captionText: string) {
+  const accessToken = process.env.FACEBOOK_GROUPS_ACCESS_TOKEN
+  if (!accessToken) throw new Error('Missing FACEBOOK_GROUPS_ACCESS_TOKEN')
+  if (!/^https?:\/\//i.test(String(publicVideoUrl || ''))) throw new Error('Facebook group posting requires a public HTTPS video URL')
+  const apiVersion = process.env.FACEBOOK_API_VERSION || 'v20.0'
+  const host = process.env.FACEBOOK_API_HOST || 'graph.facebook.com'
+  const url = `https://${host}/${apiVersion}/${groupId}/videos`
+  const response = await axios.post(url, {
+    file_url: publicVideoUrl,
+    description: captionText,
+    published: true
+  }, { headers: { Authorization: 'Bearer ' + accessToken }, timeout: 120000 })
+  const id = response.data?.id || ''
+  if (!id) throw new Error(`Facebook group ${groupId} did not return video id`)
+  return id
+}
+
+export async function postToFacebookGroups(product: any, publicVideoUrl: string, captionText: string) {
+  const config = readJson(GROUPS_CONFIG, { allowedGroupIds: [], routes: [] })
+  const allowed = new Set((config.allowedGroupIds || []).map((id: string) => String(id)))
+  const topics = inferTopics(product)
+
+  // Warn about any routes configured with groupHandle but no groupId (Graph API requires a numeric ID)
+  for (const route of (config.routes || [])) {
+    if (!route.groupId && route.groupHandle) {
+      console.log(`Facebook group route "${route.label || route.groupHandle}" has groupHandle but no groupId. The Facebook Graph API requires a numeric group ID to post videos. This group will be skipped until a groupId is added to config/facebook-groups.json.`)
+    }
+  }
+
+  const routes = (config.routes || []).filter((route: any) => {
+    const routeTopics = Array.isArray(route.topics) ? route.topics : []
+    const groupId = String(route.groupId || '')
+    return groupId && allowed.has(groupId) && routeTopics.some((topic: string) => topics.includes(topic))
+  })
+
+  const results: any[] = []
+  for (const route of routes) {
+    try {
+      const id = await postToFacebookGroup(String(route.groupId), publicVideoUrl, captionText)
+      results.push({ groupId: String(route.groupId), label: route.label, id, ok: true })
+    } catch (error: any) {
+      results.push({ groupId: String(route.groupId), label: route.label, ok: false, error: error?.message || error })
+    }
+  }
+  return results
+}

--- a/scripts/lib/ffmpeg-compositor.ts
+++ b/scripts/lib/ffmpeg-compositor.ts
@@ -1,0 +1,280 @@
+// @ts-nocheck
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+import { ensureDir, safeFileName } from './video-utils'
+
+function run(cmd: string) {
+  execSync(cmd, { stdio: 'inherit' })
+}
+
+function shellEscapeText(value: string) {
+  return String(value || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/:/g, '\\:')
+    .replace(/'/g, "\\'")
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+}
+
+function isImage(file: string) {
+  return /\.(png|jpe?g|webp)$/i.test(file)
+}
+
+function probeDuration(file: string): number {
+  try {
+    const out = execSync(`ffprobe -v error -show_entries format=duration -of csv=p=0 "${file}"`).toString().trim()
+    const n = Number(out)
+    return Number.isFinite(n) && n > 0 ? n : 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Build ONE scene clip (always 1080x1920, 30fps, no audio).
+ *   kind 'product' -> the product image is CONTAINED over a blurred copy of
+ *                     itself (never cropped) with a gentle Ken Burns push-in.
+ *   kind 'photo'   -> Pexels still: cover-crop to portrait + Ken Burns
+ *                     (alternating zoom-in / pan so consecutive stills differ).
+ *   kind 'video'   -> Pexels/local clip: cover-crop to portrait, looped/trimmed.
+ */
+function makeSceneClip(file: string, index: number, seconds: number, kind: string, outputDir: string) {
+  const duration = Math.max(3, Number(seconds || 5))
+  const frames = Math.ceil(duration * 30)
+  const clip = path.resolve(outputDir, `scene-${Date.now()}-${index}.mp4`)
+  const resolvedKind = kind || (isImage(file) ? 'photo' : 'video')
+
+  if (resolvedKind === 'product') {
+    // contain product over a blurred, cover-filled background of itself
+    run([
+      'ffmpeg -y -loglevel error',
+      '-loop 1',
+      `-i "${file}"`,
+      `-filter_complex "` +
+        `[0:v]scale=1080:1920:force_original_aspect_ratio=increase,crop=1080:1920,boxblur=40:2[bg];` +
+        `[0:v]scale=-1:1500:force_original_aspect_ratio=decrease[fg];` +
+        `[bg][fg]overlay=(W-w)/2:(H-h)/2,` +
+        `zoompan=z='min(zoom+0.0012,1.08)':x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':d=${frames}:s=1080x1920:fps=30,` +
+        `format=yuv420p"`,
+      '-an -r 30',
+      `-frames:v ${frames}`,
+      `"${clip}"`
+    ].join(' '))
+    return clip
+  }
+
+  if (resolvedKind === 'photo') {
+    // alternate the Ken Burns move so back-to-back stills feel different
+    const move = index % 3 === 0
+      ? "zoompan=z='min(zoom+0.0018,1.16)':x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)'"
+      : index % 3 === 1
+        ? `zoompan=z='1.12':x='(iw-iw/zoom)*on/${frames}':y='ih/2-(ih/zoom/2)'`            // pan right
+        : `zoompan=z='1.12':x='(iw-iw/zoom)*(1-on/${frames})':y='ih/2-(ih/zoom/2)'`        // pan left
+    run([
+      'ffmpeg -y -loglevel error',
+      '-loop 1',
+      `-i "${file}"`,
+      `-vf "scale=1080:1920:force_original_aspect_ratio=increase,crop=1080:1920,${move}:d=${frames}:s=1080x1920:fps=30,format=yuv420p"`,
+      '-an -r 30',
+      `-frames:v ${frames}`,
+      `"${clip}"`
+    ].join(' '))
+    return clip
+  }
+
+  // video
+  run([
+    'ffmpeg -y -loglevel error',
+    `-stream_loop -1 -t ${duration}`,
+    `-i "${file}"`,
+    '-vf "scale=1080:1920:force_original_aspect_ratio=increase,crop=1080:1920,setsar=1,format=yuv420p"',
+    '-an -r 30',
+    `"${clip}"`
+  ].join(' '))
+  return clip
+}
+
+
+// ---------------------------------------------------------------------------
+// Optional background music. Drop a royalty-free track at music/ (or set
+// MUSIC_FILE) and it gets ducked under the narration. Absent -> silently skipped.
+// ---------------------------------------------------------------------------
+function resolveMusicFile(): string {
+  const direct = process.env.MUSIC_FILE
+  if (direct && fs.existsSync(direct)) return direct
+  const dir = process.env.MUSIC_DIR || path.resolve(process.cwd(), 'music')
+  try {
+    if (fs.existsSync(dir)) {
+      const files = fs.readdirSync(dir)
+        .filter((x) => /\.(mp3|m4a|aac|wav|ogg)$/i.test(x))
+        .sort()
+      if (files.length) return path.resolve(dir, files[new Date().getDate() % files.length])
+    }
+  } catch {}
+  return ''
+}
+
+function drawtextFilter(text: string, opts: string) {
+  return `drawtext=text='${shellEscapeText(text)}':${opts}`
+}
+
+/**
+ * composeVerticalAd
+ *  Preferred input:
+ *    scenes: [{ file, seconds, kind: 'product'|'photo'|'video' }]
+ *  Legacy input (still supported):
+ *    sceneFiles: string[], sceneDurations?: number[], productImage?: string
+ *  Optional:
+ *    voiceoverFile  -> narration track. Visuals are sized to it.
+ *    captionText, overlayText
+ *
+ *  Render path (quality-first): per-scene clips -> ONE combined encode that
+ *  concatenates + applies product watermark + overlay + caption at -crf 19
+ *  -preset medium (previously this was 4 stacked veryfast re-encodes, which
+ *  is the main reason the output looked soft). Audio (narration + optional
+ *  ducked music) is muxed last with -c:v copy so the picture is encoded once.
+ */
+export async function composeVerticalAd(input: any) {
+  const outputDir = path.resolve(process.cwd(), 'output')
+  ensureDir(outputDir)
+
+  // Normalise to a scenes[] array with explicit kinds.
+  let scenes = Array.isArray(input.scenes) ? input.scenes.filter((s: any) => s && s.file) : []
+  if (!scenes.length) {
+    const files = input.sceneFiles || []
+    if (!files.length) throw new Error('No scene files provided to compositor')
+    const durations = input.sceneDurations || []
+    const productImage = input.productImage || ''
+    scenes = files.map((file: string, i: number) => ({
+      file,
+      seconds: durations[i] || input.sceneSeconds || 5,
+      kind: (productImage && file === productImage) ? 'product' : (isImage(file) ? 'photo' : 'video')
+    }))
+  }
+
+  // Pick an explicit fontfile so drawtext works even where fontconfig has no
+  // default sans (otherwise drawtext can fail at runtime). Empty -> ffmpeg default.
+  const FONT_CANDIDATES = [
+    process.env.DRAWTEXT_FONT || '',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+    '/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf'
+  ]
+  const fontPath = FONT_CANDIDATES.find((f) => f && fs.existsSync(f)) || ''
+  const FONT = fontPath ? `fontfile='${fontPath}':` : ''
+
+  const hasProductScene = scenes.some((s: any) => s.kind === 'product')
+
+  // Probe narration up front so the visuals can be sized to cover it in a
+  // single encode (instead of padding the finished video with another pass).
+  const voiceoverFile = input.voiceoverFile && fs.existsSync(input.voiceoverFile) ? input.voiceoverFile : ''
+  const voiceDur = voiceoverFile ? probeDuration(voiceoverFile) : 0
+  scenes = scenes.map((s: any) => ({ ...s, seconds: Math.max(3, Number(s.seconds || 5)) }))
+  let scenesTotal = scenes.reduce((sum: number, s: any) => sum + s.seconds, 0)
+  if (voiceDur > scenesTotal + 0.3) {
+    const extra = voiceDur - scenesTotal + 0.4
+    scenes[scenes.length - 1].seconds += extra
+    scenesTotal += extra
+  }
+
+  // ---- per-scene clips (motion clips looped/trimmed, stills get Ken Burns) ----
+  const sceneClips = scenes.map((s: any, i: number) =>
+    makeSceneClip(s.file, i, s.seconds, s.kind, outputDir))
+
+  const concatList = path.resolve(outputDir, `concat-${Date.now()}.txt`)
+  fs.writeFileSync(concatList, sceneClips.map((f: string) => `file '${f.replace(/'/g, "'\\''")}'`).join('\n'), 'utf8')
+
+  // ---- ONE combined video pass: concat + watermark + overlay + caption ----
+  const inputs: string[] = [`-f concat -safe 0 -i "${concatList}"`]
+  const chains: string[] = []
+  let vlabel = '0:v'
+  let nextInput = 1
+
+  if (input.productImage && !hasProductScene && fs.existsSync(input.productImage)) {
+    inputs.push(`-loop 1 -i "${input.productImage}"`)
+    chains.push(`[${nextInput}:v]scale=430:-1[prod]`)
+    chains.push(`[${vlabel}][prod]overlay=40:H-h-80:enable='between(t,1,999)'[vwm]`)
+    vlabel = 'vwm'
+    nextInput++
+  }
+  if (input.overlayText) {
+    const tf = path.resolve(outputDir, `ovl-${Date.now()}.txt`)
+    fs.writeFileSync(tf, String(input.overlayText), 'utf8')
+    chains.push(`[${vlabel}]drawtext=textfile='${tf}':${FONT}fontcolor=white:fontsize=42:borderw=4:bordercolor=black:x=40:y=90:box=1:boxcolor=black@0.35:boxborderw=18[vov]`)
+    vlabel = 'vov'
+  }
+  if (input.captionText) {
+    const tf = path.resolve(outputDir, `cap-${Date.now()}.txt`)
+    fs.writeFileSync(tf, String(input.captionText), 'utf8')
+    chains.push(`[${vlabel}]drawtext=textfile='${tf}':${FONT}fontcolor=white:fontsize=52:borderw=4:bordercolor=black:x=(w-text_w)/2:y=h-260:box=1:boxcolor=black@0.25:boxborderw=18[vcap]`)
+    vlabel = 'vcap'
+  }
+
+  const composed = path.resolve(outputDir, `composed-${Date.now()}.mp4`)
+  const QUALITY = '-c:v libx264 -preset medium -crf 19 -pix_fmt yuv420p -r 30 -movflags +faststart'
+  if (chains.length) {
+    run([
+      'ffmpeg -y -loglevel error',
+      ...inputs,
+      `-filter_complex "${chains.join(';')}"`,
+      `-map "[${vlabel}]"`,
+      QUALITY,
+      `"${composed}"`
+    ].join(' '))
+  } else {
+    run([
+      'ffmpeg -y -loglevel error',
+      `-f concat -safe 0 -i "${concatList}"`,
+      QUALITY,
+      `"${composed}"`
+    ].join(' '))
+  }
+
+  // ---- audio: narration (+ optional ducked, looped music), locked to video length ----
+  const vDur = probeDuration(composed) || scenesTotal
+  const musicFile = resolveMusicFile()
+  let working = composed
+
+  if (voiceoverFile || musicFile) {
+    const out = path.resolve(outputDir, `final-${Date.now()}.mp4`)
+    const t = vDur.toFixed(2)
+    if (voiceoverFile && musicFile) {
+      run([
+        'ffmpeg -y -loglevel error',
+        `-i "${working}"`,
+        `-i "${voiceoverFile}"`,
+        `-stream_loop -1 -i "${musicFile}"`,
+        `-filter_complex "[1:a]apad,atrim=0:${t},asetpts=N/SR/TB[vo];[2:a]volume=0.16,atrim=0:${t},asetpts=N/SR/TB[mu];[vo][mu]amix=inputs=2:duration=first:dropout_transition=0[a]"`,
+        '-map 0:v -map "[a]"',
+        '-c:v copy -c:a aac -b:a 192k',
+        `"${out}"`
+      ].join(' '))
+    } else if (voiceoverFile) {
+      run([
+        'ffmpeg -y -loglevel error',
+        `-i "${working}"`,
+        `-i "${voiceoverFile}"`,
+        `-filter_complex "[1:a]apad,atrim=0:${t},asetpts=N/SR/TB[a]"`,
+        '-map 0:v -map "[a]"',
+        '-c:v copy -c:a aac -b:a 192k',
+        `"${out}"`
+      ].join(' '))
+    } else {
+      run([
+        'ffmpeg -y -loglevel error',
+        `-i "${working}"`,
+        `-stream_loop -1 -i "${musicFile}"`,
+        `-filter_complex "[1:a]volume=0.22,atrim=0:${t},asetpts=N/SR/TB[a]"`,
+        '-map 0:v -map "[a]"',
+        '-c:v copy -c:a aac -b:a 192k',
+        `"${out}"`
+      ].join(' '))
+    }
+    working = out
+  }
+
+  const finalOutput = path.resolve(outputDir, `${safeFileName(input.outputName || 'vertical-ad', 'mp4')}`)
+  fs.copyFileSync(working, finalOutput)
+  return finalOutput
+}

--- a/scripts/lib/marketing-engine.ts
+++ b/scripts/lib/marketing-engine.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+import fs from 'fs'
+import path from 'path'
+import OpenAI from 'openai'
+import { readJson, writeJson, slugify } from './video-utils'
+
+const ROOT = process.cwd()
+const ANALYTICS_FILE = path.resolve(ROOT, process.env.VIDEO_ANALYTICS_FILE || 'data/video-analytics.json')
+const TRENDS_FILE = path.resolve(ROOT, process.env.TRENDS_FILE || 'data/trends.json')
+
+export function amazonAttributionUrl(product: any, campaign = 'social_video') {
+  const base = product.amazonUrl || product.websiteUrl || ''
+  if (!base) return ''
+  const separator = base.includes('?') ? '&' : '?'
+  const source = encodeURIComponent(process.env.ATTRIBUTION_SOURCE || 'social')
+  const medium = encodeURIComponent(process.env.ATTRIBUTION_MEDIUM || 'short_video')
+  const content = encodeURIComponent(slugify(product.name || product.id || 'product'))
+  return `${base}${separator}utm_source=${source}&utm_medium=${medium}&utm_campaign=${encodeURIComponent(campaign)}&utm_content=${content}`
+}
+
+export function recordPerformance(input: any) {
+  const analytics = readJson(ANALYTICS_FILE, { hooks: {}, videos: [] })
+  analytics.videos.push({ ...input, recordedAt: new Date().toISOString() })
+  if (input.hook) {
+    analytics.hooks[input.hook] = analytics.hooks[input.hook] || { uses: 0, views: 0, likes: 0, comments: 0, clicks: 0, score: 0 }
+    analytics.hooks[input.hook].uses += 1
+    analytics.hooks[input.hook].views += Number(input.views || 0)
+    analytics.hooks[input.hook].likes += Number(input.likes || 0)
+    analytics.hooks[input.hook].comments += Number(input.comments || 0)
+    analytics.hooks[input.hook].clicks += Number(input.clicks || 0)
+    analytics.hooks[input.hook].score =
+      analytics.hooks[input.hook].likes * 2 + analytics.hooks[input.hook].comments * 3 + analytics.hooks[input.hook].clicks * 5 + analytics.hooks[input.hook].views * 0.01
+  }
+  analytics.lastUpdatedAt = new Date().toISOString()
+  writeJson(ANALYTICS_FILE, analytics)
+  return analytics
+}
+
+export function pickABVariant(product: any) {
+  const analytics = readJson(ANALYTICS_FILE, { hooks: {}, videos: [] })
+  const candidates = [
+    'problem_first',
+    'before_after',
+    'product_demo',
+    'soil_science_simple',
+    'price_value',
+    'farmer_plainspoken'
+  ]
+  const counts = Object.fromEntries(candidates.map((c) => [c, 0]))
+  for (const video of analytics.videos || []) {
+    if (video.productId === product.id && video.variant && counts[video.variant] !== undefined) counts[video.variant]++
+  }
+  const variantScores: Record<string, number> = Object.fromEntries(candidates.map((c) => [c, 0]))
+  for (const video of analytics.videos || []) {
+    if (video.productId !== product.id || !video.variant || variantScores[video.variant] === undefined) continue
+    const likes = Number(video.likes || 0)
+    const comments = Number(video.comments || 0)
+    const clicks = Number(video.clicks || 0)
+    const views = Number(video.views || 0)
+    variantScores[video.variant] += (likes * 2) + (comments * 3) + (clicks * 5) + (views * 0.01)
+  }
+
+  return candidates.sort((a, b) => {
+    const scoreDiff = variantScores[b] - variantScores[a]
+    if (scoreDiff !== 0) return scoreDiff
+    return counts[a] - counts[b]
+  })[0]
+}
+
+export async function generateTrendAwareHooks(product: any, profile: any) {
+  const trends = readJson(TRENDS_FILE, { trends: [] })
+  if (!process.env.OPENAI_API_KEY) return profile.hooks || []
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  const prompt = `Create 8 short high-retention hooks for a vertical video ad.
+Product: ${product.name}
+Description: ${product.description}
+Audience: ${profile.audience || 'homeowners, gardeners, lawn care, pasture owners'}
+Current trend notes: ${(trends.trends || []).slice(0, 10).join(' | ')}
+Rules: no exaggerated guarantees, no disease/pesticide claims, sound natural, first 3 seconds only.
+Return JSON only: {"hooks":["..."]}`
+  const res = await client.chat.completions.create({ model: process.env.OPENAI_MODEL || 'gpt-4o-mini', messages: [{ role: 'user', content: prompt }], temperature: 0.8, max_tokens: 500 })
+  const text = res.choices[0]?.message?.content || ''
+  const match = text.match(/\{[\s\S]*\}/)
+  if (!match) return profile.hooks || []
+  try {
+    const parsed = JSON.parse(match[0])
+    return Array.isArray(parsed.hooks) ? parsed.hooks : (profile.hooks || [])
+  } catch {
+    return profile.hooks || []
+  }
+}
+
+export function updateTrendsManually(items: string[]) {
+  const payload = { updatedAt: new Date().toISOString(), trends: items.filter(Boolean).slice(0, 50) }
+  writeJson(TRENDS_FILE, payload)
+  return payload
+}

--- a/scripts/lib/narration.ts
+++ b/scripts/lib/narration.ts
@@ -1,0 +1,63 @@
+// @ts-nocheck
+import fs from 'fs'
+import path from 'path'
+import OpenAI from 'openai'
+import { execSync } from 'child_process'
+import { ensureDir, safeFileName } from './video-utils'
+
+/**
+ * Generate a voiceover audio file using OpenAI TTS only.
+ */
+export async function generateVoiceover(product: any, scenePlan: any, profile: any, outDir: string): Promise<string> {
+  const script = (scenePlan?.fullVoiceover || (scenePlan?.scenes || []).map((s: any) => s.voiceover).filter(Boolean).join(' ') || '').trim()
+  if (!script) {
+    console.log('Narration skipped: empty script')
+    return ''
+  }
+  if (!process.env.OPENAI_API_KEY) {
+    console.log('Narration skipped: missing OPENAI_API_KEY')
+    return ''
+  }
+
+  ensureDir(outDir)
+  const ttsMp3 = path.resolve(outDir, `tts-${safeFileName(product.id || product.name, 'mp3')}`)
+  const audioOut = path.resolve(outDir, `voiceover-${safeFileName(product.id || product.name, 'm4a')}`)
+
+  try {
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+    const model = process.env.TTS_MODEL || 'gpt-4o-mini-tts'
+    const voice = process.env.TTS_VOICE || 'alloy'
+    const response = await client.audio.speech.create({
+      model,
+      voice: voice as any,
+      input: script,
+      format: 'mp3'
+    } as any)
+    const buffer = Buffer.from(await response.arrayBuffer())
+    fs.writeFileSync(ttsMp3, buffer)
+
+    execSync([
+      'ffmpeg -y -loglevel error',
+      `-i "${ttsMp3}"`,
+      '-af "loudnorm=I=-16:TP=-1.5:LRA=11"',
+      '-c:a aac -b:a 192k',
+      `"${audioOut}"`
+    ].join(' '), { stdio: 'inherit' })
+
+    if (fs.existsSync(audioOut) && fs.statSync(audioOut).size > 0) {
+      console.log('Narration ready', { audioOut })
+      try { fs.unlinkSync(ttsMp3) } catch {}
+      return audioOut
+    }
+    if (fs.existsSync(ttsMp3) && fs.statSync(ttsMp3).size > 0) {
+      console.log('Narration fallback: using raw mp3 output')
+      return ttsMp3
+    }
+    console.log('Narration skipped: TTS produced no output')
+    return ''
+  } catch (error: any) {
+    console.log('Narration generation failed; continuing without audio', { error: error?.message || error })
+    try { if (fs.existsSync(ttsMp3)) fs.unlinkSync(ttsMp3) } catch {}
+    return ''
+  }
+}

--- a/scripts/lib/pexels-media.ts
+++ b/scripts/lib/pexels-media.ts
@@ -1,0 +1,179 @@
+// @ts-nocheck
+import axios from 'axios'
+import fs from 'fs'
+import path from 'path'
+import { ensureDir, safeFileName } from './video-utils'
+
+const PEXELS_VIDEO_API = 'https://api.pexels.com/videos/search'
+const PEXELS_PHOTO_API = 'https://api.pexels.com/v1/search'
+
+function trimQuery(query: string, words = 4) {
+  return String(query || '').split(/\s+/).filter(Boolean).slice(0, words).join(' ')
+}
+
+function uniqQueries(items: string[]) {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const item of items) {
+    const value = String(item || '').trim()
+    if (!value) continue
+    const key = value.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(value)
+  }
+  return out
+}
+
+export function buildSceneQueryPriority(scene: any, product: any, index = 0) {
+  const scenePrimary = String(scene?.brollQuery || '').trim()
+  const sceneList = Array.isArray(scene?.brollQueries) ? scene.brollQueries : []
+  const productFallback = Array.isArray(product?.brollQueries) ? product.brollQueries[index] : ''
+  const categoryFallback = String(product?.category || '').trim()
+  return uniqQueries([scenePrimary, ...sceneList, productFallback, categoryFallback])
+}
+
+/**
+ * Build the search attempts for a query. We keep the attempts CLOSE to the
+ * product (full query -> trimmed query) and only fall back to a generic term
+ * as a last resort. Previously the chain degraded straight to "green lawn",
+ * which is the main reason b-roll looked generic and unrelated to the product.
+ */
+function videoAttempts(query: string) {
+  const q = String(query || '').trim()
+  const short = trimQuery(q, 3)
+  return [
+    { query: q, orientation: 'portrait' },
+    { query: q, orientation: 'landscape' },
+    short !== q ? { query: short, orientation: 'portrait' } : null,
+    short !== q ? { query: short, orientation: 'landscape' } : null
+  ].filter(Boolean)
+}
+
+// ---------------------------------------------------------------------------
+// VIDEO b-roll
+// ---------------------------------------------------------------------------
+export async function findPexelsVideoUrl(query: string) {
+  const key = process.env.PEXELS_API_KEY
+  if (!key) {
+    console.log('Pexels skipped: missing PEXELS_API_KEY')
+    return ''
+  }
+
+  for (const attempt of videoAttempts(query)) {
+    try {
+      const response = await axios.get(PEXELS_VIDEO_API, {
+        headers: { Authorization: key },
+        params: { query: attempt.query, orientation: attempt.orientation, per_page: 15 },
+        timeout: 30000
+      })
+      const videos = Array.isArray(response.data?.videos) ? response.data.videos : []
+      console.log('Pexels video search', { query: attempt.query, orientation: attempt.orientation, count: videos.length })
+
+      // Prefer real portrait clips at a sane resolution (>=720 wide, <=2160),
+      // so we don't grab a 4K landscape file and hard-crop it to a sliver.
+      const ranked = videos
+        .map((video: any) => {
+          const files = video.video_files || []
+          const portrait = files
+            .filter((f: any) => Number(f.height || 0) >= Number(f.width || 0))
+            .sort((a: any, b: any) => Math.abs(1080 - Number(a.width || 0)) - Math.abs(1080 - Number(b.width || 0)))[0]
+          const any = files.sort((a: any, b: any) => Math.abs(1080 - Number(a.width || 0)) - Math.abs(1080 - Number(b.width || 0)))[0]
+          const best = portrait || any
+          return { id: video.id, url: best?.link || '', width: best?.width || 0, height: best?.height || 0, isPortrait: !!portrait }
+        })
+        .filter((item: any) => item.url)
+        // portrait first, then closeness to 1080 wide
+        .sort((a: any, b: any) => (Number(b.isPortrait) - Number(a.isPortrait)) || (Math.abs(1080 - a.width) - Math.abs(1080 - b.width)))
+
+      if (ranked[0]) {
+        console.log('Selected Pexels video', { query: attempt.query, id: ranked[0].id, res: `${ranked[0].width}x${ranked[0].height}`, portrait: ranked[0].isPortrait })
+        return ranked[0].url
+      }
+    } catch (error: any) {
+      console.log('Pexels video search failed', { query: attempt.query, status: error?.response?.status, message: error?.message })
+    }
+  }
+  return ''
+}
+
+// ---------------------------------------------------------------------------
+// PHOTO b-roll (used for Ken Burns scenes)
+// ---------------------------------------------------------------------------
+export async function findPexelsPhotoUrl(query: string) {
+  const key = process.env.PEXELS_API_KEY
+  if (!key) {
+    console.log('Pexels skipped: missing PEXELS_API_KEY')
+    return ''
+  }
+
+  const attempts = [
+    { query: String(query || '').trim(), orientation: 'portrait' },
+    { query: trimQuery(query, 3), orientation: 'portrait' },
+    { query: String(query || '').trim(), orientation: 'landscape' }
+  ]
+
+  for (const attempt of attempts) {
+    try {
+      const response = await axios.get(PEXELS_PHOTO_API, {
+        headers: { Authorization: key },
+        params: { query: attempt.query, orientation: attempt.orientation, per_page: 15 },
+        timeout: 30000
+      })
+      const photos = Array.isArray(response.data?.photos) ? response.data.photos : []
+      console.log('Pexels photo search', { query: attempt.query, orientation: attempt.orientation, count: photos.length })
+      const first = photos[0]
+      // large2x (~1880px) is plenty for a 1080x1920 Ken Burns frame; original is huge.
+      const url = first?.src?.large2x || first?.src?.original || first?.src?.large || ''
+      if (url) {
+        console.log('Selected Pexels photo', { query: attempt.query, id: first?.id })
+        return url
+      }
+    } catch (error: any) {
+      console.log('Pexels photo search failed', { query: attempt.query, status: error?.response?.status, message: error?.message })
+    }
+  }
+  return ''
+}
+
+export async function downloadUrl(url: string, outputFile: string) {
+  ensureDir(path.dirname(outputFile))
+  const response = await axios.get(url, { responseType: 'stream', timeout: 120000 })
+  await new Promise((resolve, reject) => {
+    const writer = fs.createWriteStream(outputFile)
+    response.data.pipe(writer)
+    writer.on('finish', resolve)
+    writer.on('error', reject)
+  })
+  return outputFile
+}
+
+export async function downloadPexelsVideo(query: string, outputDir: string, index = 0) {
+  const url = await findPexelsVideoUrl(query)
+  if (!url) return ''
+  const file = path.resolve(outputDir, `${String(index + 1).padStart(2, '0')}-vid-${safeFileName(query, 'mp4')}`)
+  return await downloadUrl(url, file)
+}
+
+export async function downloadPexelsPhoto(query: string, outputDir: string, index = 0) {
+  const url = await findPexelsPhotoUrl(query)
+  if (!url) return ''
+  const ext = (url.split('?')[0].toLowerCase().endsWith('.png')) ? 'png' : 'jpg'
+  const file = path.resolve(outputDir, `${String(index + 1).padStart(2, '0')}-img-${safeFileName(query, ext)}`)
+  return await downloadUrl(url, file)
+}
+
+export async function fetchBrollForScene(scene: any, product: any, outputDir: string, index = 0) {
+  const attempts = buildSceneQueryPriority(scene, product, index)
+  for (const query of attempts) {
+    try {
+      const videoFile = await downloadPexelsVideo(query, outputDir, index)
+      if (videoFile) return { file: videoFile, kind: 'video', query }
+    } catch {}
+    try {
+      const photoFile = await downloadPexelsPhoto(query, outputDir, index)
+      if (photoFile) return { file: photoFile, kind: 'photo', query }
+    } catch {}
+  }
+  return null
+}

--- a/scripts/lib/product-assets.ts
+++ b/scripts/lib/product-assets.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import axios from 'axios'
+import fs from 'fs'
+import path from 'path'
+import { ensureDir, safeFileName } from './video-utils'
+
+const ROOT = process.cwd()
+const PRODUCT_ASSET_DIR = path.resolve(ROOT, 'assets/products')
+const DEFAULT_SITE_BASE_URL = 'https://www.natureswaysoil.com'
+
+export function localProductImage(product: any) {
+  const candidates = [
+    path.resolve(PRODUCT_ASSET_DIR, `${product.id}.png`),
+    path.resolve(PRODUCT_ASSET_DIR, `${product.id}.jpg`),
+    path.resolve(PRODUCT_ASSET_DIR, `${safeFileName(product.name, 'png')}`),
+    path.resolve(PRODUCT_ASSET_DIR, `${safeFileName(product.name, 'jpg')}`)
+  ]
+  return candidates.find((file) => fs.existsSync(file)) || ''
+}
+
+function encodeUrlPath(url: string) {
+  try {
+    const parsed = new URL(url)
+    parsed.pathname = parsed.pathname
+      .split('/')
+      .map((part) => encodeURIComponent(decodeURIComponent(part)))
+      .join('/')
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+function productImageSource(product: any) {
+  const source = product.productImageUrl || product.imageUrl || product.amazonImageUrl || product.productImagePath || product.imagePath || ''
+  if (!source) return ''
+  if (/^https?:\/\//i.test(source)) return encodeUrlPath(source)
+  if (String(source).startsWith('/')) {
+    const base = (process.env.PRODUCT_IMAGE_BASE_URL || DEFAULT_SITE_BASE_URL).replace(/\/$/, '')
+    return encodeUrlPath(`${base}${source}`)
+  }
+  return source
+}
+
+function imageExtension(url: string) {
+  const clean = String(url || '').split('?')[0].toLowerCase()
+  if (clean.endsWith('.png')) return 'png'
+  if (clean.endsWith('.webp')) return 'webp'
+  return 'jpg'
+}
+
+export async function downloadProductImage(product: any, outputDir: string) {
+  const local = localProductImage(product)
+  if (local) return local
+
+  const url = productImageSource(product)
+  if (!url) return ''
+
+  ensureDir(outputDir)
+  const ext = imageExtension(url)
+  const output = path.resolve(outputDir, `product-${product.id}.${ext}`)
+
+  try {
+    const response = await axios.get(url, { responseType: 'stream', timeout: 60000 })
+    await new Promise((resolve, reject) => {
+      const writer = fs.createWriteStream(output)
+      response.data.pipe(writer)
+      writer.on('finish', resolve)
+      writer.on('error', reject)
+    })
+    return output
+  } catch (error: any) {
+    console.log('Product image skipped; continuing with b-roll only', {
+      productId: product.id,
+      source: url,
+      error: error?.response?.status || error?.message || error
+    })
+    try { if (fs.existsSync(output)) fs.unlinkSync(output) } catch {}
+    return ''
+  }
+}
+
+export function productOverlayText(product: any) {
+  if (/2\.5|pasture|hay|acre/i.test(`${product.name} ${product.description}`)) return 'COVERS UP TO 2–5 ACRES'
+  if (/dog|urine|odor|pet/i.test(`${product.name} ${product.description}`)) return 'PET-SAFE OUTDOOR SUPPORT'
+  if (/worm|biochar|compost|living soil/i.test(`${product.name} ${product.description}`)) return 'WORM CASTINGS + BIOCHAR'
+  if (/humic|fulvic|kelp/i.test(`${product.name} ${product.description}`)) return 'HUMIC + FULVIC + KELP'
+  return 'SOIL-FIRST SUPPORT'
+}

--- a/scripts/lib/social-platforms.ts
+++ b/scripts/lib/social-platforms.ts
@@ -1,0 +1,172 @@
+import axios from 'axios'
+import { google } from 'googleapis'
+import { TwitterApi } from 'twitter-api-v2'
+
+function pickEnv(keys: string[]): string {
+  for (const key of keys) {
+    const value = process.env[key]?.trim()
+    if (value) return value
+  }
+  return ''
+}
+
+function apiError(error: any): string {
+  const status = error?.response?.status
+  const body = error?.response?.data
+  const detail = body?.error?.message || body?.message || error?.message || String(error)
+  return status ? `HTTP ${status}: ${detail}` : detail
+}
+
+// ---------------------------------------------------------------------------
+// Twitter / X video posting via twitter-api-v2 (matches the proven path used
+// in the social-video-automation repo). Accepts a LOCAL file path (preferred)
+// or a public URL (downloaded to a temp file first). OAuth 1.0a user context.
+// Secrets: TWITTER_API_KEY, TWITTER_API_SECRET, TWITTER_ACCESS_TOKEN,
+//          TWITTER_ACCESS_TOKEN_SECRET || TWITTER_ACCESS_SECRET
+// ---------------------------------------------------------------------------
+export async function postToTwitter(videoFileOrUrl: string, caption: string) {
+  const appKey = process.env.TWITTER_API_KEY
+  const appSecret = process.env.TWITTER_API_SECRET
+  const accessToken = process.env.TWITTER_ACCESS_TOKEN
+  const accessSecret = process.env.TWITTER_ACCESS_TOKEN_SECRET || process.env.TWITTER_ACCESS_SECRET
+  if (!appKey || !appSecret || !accessToken || !accessSecret) {
+    console.log('Twitter posting skipped: missing TWITTER_API_KEY/API_SECRET/ACCESS_TOKEN/ACCESS_SECRET')
+    return { skipped: true }
+  }
+
+  const client = new TwitterApi({ appKey, appSecret, accessToken, accessSecret })
+
+  // Resolve to a local file path; download if a URL was passed.
+  let localPath = videoFileOrUrl
+  let cleanup = false
+  if (/^https?:\/\//i.test(videoFileOrUrl)) {
+    const fs = await import('fs')
+    const os = await import('os')
+    const path = await import('path')
+    const tmp = path.join(os.tmpdir(), `tw-${Date.now()}.mp4`)
+    const resp = await axios.get(videoFileOrUrl, { responseType: 'arraybuffer', timeout: 180000 })
+    fs.writeFileSync(tmp, Buffer.from(resp.data))
+    localPath = tmp
+    cleanup = true
+  }
+
+  try {
+    // v1.1 chunked uploader first (most reliable for video); fall back to v2.
+    let mediaId: string
+    try {
+      mediaId = await client.v1.uploadMedia(localPath, { mimeType: 'video/mp4', target: 'tweet' })
+    } catch (e: any) {
+      const fsBuf = await import('fs')
+      const buf = fsBuf.readFileSync(localPath)
+      mediaId = await client.v2.uploadMedia(buf, { media_type: 'video/mp4', media_category: 'tweet_video' })
+    }
+    const { data } = await client.v2.tweet({ text: String(caption || '').slice(0, 280), media: { media_ids: [mediaId] } })
+    const tweetId = data?.id
+    if (!tweetId) throw new Error('Twitter did not return a tweet id')
+    return { platform: 'twitter', tweetId, mediaId }
+  } finally {
+    if (cleanup) { try { (await import('fs')).unlinkSync(localPath) } catch {} }
+  }
+}
+
+export async function postToTikTok(videoUrl: string, caption: string) {
+  const accessToken = process.env.TIKTOK_ACCESS_TOKEN
+  const openId = process.env.TIKTOK_OPEN_ID
+  if (!accessToken || !openId) {
+    console.log('TikTok posting skipped: missing TIKTOK_ACCESS_TOKEN or TIKTOK_OPEN_ID')
+    return { skipped: true }
+  }
+  if (!/^https?:\/\//i.test(videoUrl)) throw new Error('TikTok posting requires a public HTTPS video URL')
+
+  const host = process.env.TIKTOK_API_HOST || 'open.tiktokapis.com'
+  const init = await axios.post(`https://${host}/v2/post/publish/video/init/`, {
+    post_info: { title: caption.slice(0, 2200), privacy_level: 'PUBLIC_TO_EVERYONE', disable_duet: false, disable_comment: false, disable_stitch: false },
+    source_info: { source: 'PULL_FROM_URL', video_url: videoUrl }
+  }, { headers: { Authorization: 'Bearer ' + accessToken }, timeout: 120000 })
+
+  const publishId = init.data?.data?.publish_id || init.data?.publish_id || ''
+  if (!publishId) throw new Error(`TikTok init failed: ${JSON.stringify(init.data)}`)
+
+  return { platform: 'tiktok', publishId, status: init.data?.data?.status || init.data?.status || 'submitted' }
+}
+
+export async function postToFacebookReels(videoUrl: string, caption: string) {
+  if (!process.env.FACEBOOK_PAGE_ACCESS_TOKEN || !process.env.FACEBOOK_PAGE_ID) {
+    console.log('Facebook Reels skipped: missing page credentials')
+    return { skipped: true }
+  }
+  return { platform: 'facebook_reels', queued: true, videoUrl, caption }
+}
+
+export async function autoReplyTemplates() {
+  return [
+    'Thanks for checking out Nature\'s Way Soil.',
+    'We appreciate the support.',
+    'Let us know if you have application questions.',
+    'Thanks for supporting a small family business.'
+  ]
+}
+
+export async function fetchBasicMetrics(videoIds: { youtubeId?: string, instagramId?: string, facebookId?: string }) {
+  const metrics: any = {
+    youtube: { views: 0, likes: 0, comments: 0 },
+    instagram: { views: 0, likes: 0, comments: 0, reach: 0 },
+    facebook: { views: 0, likes: 0, comments: 0 }
+  }
+  if (videoIds.youtubeId) {
+    try {
+      const clientId = pickEnv(['YT_CLIENT_ID', 'YOUTUBE_CLIENT_ID'])
+      const clientSecret = pickEnv(['YT_CLIENT_SECRET', 'YOUTUBE_CLIENT_SECRET'])
+      const refreshToken = pickEnv(['YT_REFRESH_TOKEN', 'YOUTUBE_REFRESH_TOKEN'])
+      if (clientId && clientSecret && refreshToken) {
+        const oauth2Client = new google.auth.OAuth2({ clientId, clientSecret })
+        oauth2Client.setCredentials({ refresh_token: refreshToken })
+        const youtube = google.youtube({ version: 'v3', auth: oauth2Client })
+        const response = await youtube.videos.list({ part: ['statistics'], id: [videoIds.youtubeId] })
+        const stats = response.data.items?.[0]?.statistics
+        metrics.youtube = { views: Number(stats?.viewCount || 0), likes: Number(stats?.likeCount || 0), comments: Number(stats?.commentCount || 0) }
+      }
+    } catch (error: any) { metrics.youtube.error = error?.message || String(error) }
+  }
+  if (videoIds.instagramId && process.env.INSTAGRAM_ACCESS_TOKEN) {
+    try {
+      const apiVersion = process.env.INSTAGRAM_API_VERSION || 'v20.0'
+      const host = process.env.INSTAGRAM_API_HOST || 'graph.facebook.com'
+      const response = await axios.get(`https://${host}/${apiVersion}/${videoIds.instagramId}`, {
+        params: { fields: 'like_count,comments_count' },
+        headers: { Authorization: 'Bearer ' + process.env.INSTAGRAM_ACCESS_TOKEN }, timeout: 60000
+      })
+      metrics.instagram.likes = Number(response.data?.like_count || 0)
+      metrics.instagram.comments = Number(response.data?.comments_count || 0)
+
+      try {
+        const insights = await axios.get(`https://${host}/${apiVersion}/${videoIds.instagramId}/insights`, {
+          params: { metric: 'views,reach' },
+          headers: { Authorization: 'Bearer ' + process.env.INSTAGRAM_ACCESS_TOKEN }, timeout: 60000
+        })
+        for (const item of insights.data?.data || []) {
+          if (item.name === 'views') metrics.instagram.views = Number(item.values?.[0]?.value || item.total_value?.value || 0)
+          if (item.name === 'reach') metrics.instagram.reach = Number(item.values?.[0]?.value || item.total_value?.value || 0)
+        }
+      } catch (error: any) {
+        metrics.instagram.insightsError = apiError(error)
+      }
+    } catch (error: any) { metrics.instagram.error = apiError(error) }
+  }
+  if (videoIds.facebookId) {
+    try {
+      const accessToken = pickEnv(['FB_PAGE_ACCESS_TOKEN', 'FACEBOOK_PAGE_ACCESS_TOKEN'])
+      if (accessToken) {
+        const apiVersion = process.env.FACEBOOK_API_VERSION || process.env.INSTAGRAM_API_VERSION || 'v20.0'
+        const host = process.env.FACEBOOK_API_HOST || 'graph.facebook.com'
+        const summary = await axios.get(`https://${host}/${apiVersion}/${videoIds.facebookId}`, {
+          params: { fields: 'reactions.summary(true),comments.summary(true)' },
+          headers: { Authorization: 'Bearer ' + accessToken }, timeout: 60000
+        })
+        metrics.facebook.likes = Number(summary.data?.reactions?.summary?.total_count || 0)
+        metrics.facebook.comments = Number(summary.data?.comments?.summary?.total_count || 0)
+      }
+    } catch (error: any) { metrics.facebook.error = apiError(error) }
+  }
+  return metrics
+}

--- a/scripts/lib/video-provider.ts
+++ b/scripts/lib/video-provider.ts
@@ -1,0 +1,11 @@
+import { generateVoiceover } from './narration'
+
+export async function createNarration(product: any, scenePlan: any, profile: any, outDir: string) {
+  const requested = String(process.env.VIDEO_PROVIDER || 'openai_tts').toLowerCase()
+
+  if (requested !== 'openai_tts') {
+    console.log(`VIDEO_PROVIDER=${requested} requested but OpenAI TTS is enforced for this automation`)
+  }
+
+  return await generateVoiceover(product, scenePlan, profile, outDir)
+}

--- a/scripts/lib/video-utils.ts
+++ b/scripts/lib/video-utils.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import fs from 'fs'
+import path from 'path'
+
+export function ensureDir(dir: string) {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+export function slugify(input: string) {
+  return String(input || 'video')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'video'
+}
+
+export function wrapCaption(text: string, max = 28) {
+  const words = String(text || '').replace(/\s+/g, ' ').trim().split(' ')
+  const lines: string[] = []
+  let line = ''
+  for (const word of words) {
+    const next = line ? `${line} ${word}` : word
+    if (next.length > max && line) {
+      lines.push(line)
+      line = word
+    } else {
+      line = next
+    }
+  }
+  if (line) lines.push(line)
+  return lines.slice(0, 3).join('\\n')
+}
+
+export function safeFileName(input: string, ext = '') {
+  const base = slugify(input)
+  return ext ? `${base}.${ext.replace(/^\./, '')}` : base
+}
+
+export function readJson(file: string, fallback: any) {
+  try {
+    if (!fs.existsSync(file)) return fallback
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+export function writeJson(file: string, data: any) {
+  ensureDir(path.dirname(file))
+  fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf8')
+}
+
+export function pickHook(product: any, profile: any, analytics: any) {
+  const hooks = Array.isArray(profile?.hooks) && profile.hooks.length
+    ? profile.hooks
+    : [
+        `Stop treating the grass. Start feeding the soil.`,
+        `Your lawn problem may actually be a soil problem.`,
+        `This is a better way to support stressed grass.`,
+        `For better growth, start below the surface.`
+      ]
+
+  const scores = analytics?.hookScores || {}
+  const ranked = hooks
+    .map((hook: string, index: number) => ({ hook, index, score: Number(scores[hook]?.score || 0), uses: Number(scores[hook]?.uses || 0) }))
+    .sort((a: any, b: any) => (b.score - a.score) || (a.uses - b.uses) || (a.index - b.index))
+
+  return ranked[0]?.hook || hooks[0]
+}
+
+export function recordHookUse(analyticsFile: string, hook: string, productId: string) {
+  const analytics = readJson(analyticsFile, { hookScores: {}, productRuns: {} })
+  analytics.hookScores[hook] = analytics.hookScores[hook] || { uses: 0, score: 0 }
+  analytics.hookScores[hook].uses += 1
+  analytics.productRuns[productId] = analytics.productRuns[productId] || { runs: 0 }
+  analytics.productRuns[productId].runs += 1
+  analytics.lastUpdatedAt = new Date().toISOString()
+  writeJson(analyticsFile, analytics)
+  return analytics
+}

--- a/scripts/post-scheduled.ts
+++ b/scripts/post-scheduled.ts
@@ -1,0 +1,744 @@
+// @ts-nocheck
+import 'dotenv/config'
+import fs from 'fs'
+import path from 'path'
+import axios from 'axios'
+import OpenAI from 'openai'
+import { execSync } from 'child_process'
+import { google } from 'googleapis'
+import { Storage } from '@google-cloud/storage'
+import { SecretManagerServiceClient } from '@google-cloud/secret-manager'
+import { composeVerticalAd } from './lib/ffmpeg-compositor'
+import { buildSceneQueryPriority, fetchBrollForScene } from './lib/pexels-media'
+import { downloadProductImage, productOverlayText } from './lib/product-assets'
+import { ensureDir, safeFileName } from './lib/video-utils'
+import { createNarration } from './lib/video-provider'
+import { formatCaption } from './lib/caption-formatter'
+import { postToTikTok, postToTwitter, fetchBasicMetrics } from './lib/social-platforms'
+import { postToFacebookGroups } from './lib/facebook-groups'
+import { recordPerformance } from './lib/marketing-engine'
+
+type Product = {
+  id: string
+  name: string
+  description: string
+  category: string
+  websiteUrl: string
+  amazonUrl?: string
+  keywords?: string[]
+  brollQueries?: string[]
+  productImageUrl?: string
+}
+
+type State = {
+  cursor: number
+  variationByProduct: Record<string, number>
+  lastRunAt?: string
+}
+
+type CreativeScene = {
+  name: string
+  seconds?: number
+  voiceover?: string
+  brollQueries?: string[]
+  brollQuery?: string
+  caption?: string
+  useProductImage?: boolean
+}
+
+type RenderScene = {
+  file: string
+  seconds: number
+  kind: 'video' | 'photo' | 'product'
+  query?: string
+  source?: 'product_image' | 'local' | 'pexels_video' | 'pexels_photo'
+}
+
+type CreativeProfile = {
+  audience?: string
+  angle?: string
+  tone?: string
+  cta?: string
+  hooks?: string[]
+  scenes?: CreativeScene[]
+}
+
+const ROOT = process.cwd()
+const CONFIG_PATH = path.resolve(ROOT, 'config/top-products.json')
+const STATE_PATH = path.resolve(ROOT, process.env.ROTATION_STATE_FILE || 'data/rotation-state.json')
+const CREATIVE_PATH = path.resolve(ROOT, 'config/creative-profiles.json')
+const OUTPUT_DIR = path.resolve(ROOT, 'output')
+const TEMP_DIR = path.resolve(ROOT, 'temp-scheduled')
+const FOOTAGE_DIR = path.resolve(ROOT, process.env.FOOTAGE_DIR || 'footage')
+const DEFAULT_PUBLIC_VIDEO_BUCKET = 'natureswaysoil-social-videos'
+const DEFAULT_STATE: State = { cursor: -1, variationByProduct: {} }
+const VIDEO_ANALYTICS_FILE = path.resolve(ROOT, process.env.VIDEO_ANALYTICS_FILE || 'data/video-analytics.json')
+
+const SECRET_NAMES = [
+  'OPENAI_API_KEY',
+  'OPENAI_MODEL',
+  'PEXELS_API_KEY',
+  'YT_CLIENT_ID',
+  'YT_CLIENT_SECRET',
+  'YT_REFRESH_TOKEN',
+  'YOUTUBE_CLIENT_ID',
+  'YOUTUBE_CLIENT_SECRET',
+  'YOUTUBE_REFRESH_TOKEN',
+  'INSTAGRAM_ACCESS_TOKEN',
+  'INSTAGRAM_IG_ID',
+  'INSTAGRAM_USER_ID',
+  'INSTAGRAM_ACCOUNT_ID',
+  'FB_PAGE_ACCESS_TOKEN',
+  'FB_PAGE_ID',
+  'FACEBOOK_PAGE_ACCESS_TOKEN',
+  'FACEBOOK_PAGE_ID',
+  'FACEBOOK_GROUPS_ACCESS_TOKEN',
+  'TIKTOK_ACCESS_TOKEN',
+  'TIKTOK_OPEN_ID',
+  'TWITTER_API_KEY',
+  'TWITTER_API_SECRET',
+  'TWITTER_ACCESS_TOKEN',
+  'TWITTER_ACCESS_SECRET',
+  'GCS_PUBLIC_BUCKET',
+  'VIDEO_PUBLIC_BUCKET',
+  'VIDEO_PUBLIC_URL_BASE'
+]
+
+function log(message: string, data?: any) {
+  if (data === undefined) console.log(message)
+  else console.log(message, data)
+}
+
+function hasValue(name: string): boolean {
+  const value = process.env[name]
+  if (!value) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized !== '' && !/your-|your_|changeme|placeholder|paste_|replace_|dummy_|example_/i.test(normalized)
+}
+
+function secretCandidates(name: string): string[] {
+  const upper = name.trim().replace(/[\s-]+/g, '_').toUpperCase()
+  const lowerHyphen = upper.toLowerCase().replace(/_/g, '-')
+  const lowerUnderscore = upper.toLowerCase()
+  return [...new Set([upper, lowerHyphen, name, name.replace(/_/g, '-'), lowerUnderscore])]
+}
+
+function isNotFoundSecretError(error: any): boolean {
+  return Number(error?.code) === 5 || String(error?.message || '').toUpperCase().includes('NOT_FOUND')
+}
+
+function isPermissionDeniedSecretError(error: any): boolean {
+  const message = String(error?.message || '').toUpperCase()
+  return Number(error?.code) === 7 || message.includes('PERMISSION_DENIED') || message.includes('PERMISSION DENIED')
+}
+
+async function loadSecrets() {
+  const useSecretManager = String(process.env.USE_SECRET_MANAGER || 'true').toLowerCase() !== 'false'
+  if (!useSecretManager) return
+  const enforceSecretManagerAccess = String(process.env.REQUIRE_SECRET_MANAGER_ACCESS || process.env.CI || '').toLowerCase() === 'true'
+  const dryRun = String(process.env.DRY_RUN_LOG_ONLY || '').toLowerCase() === 'true'
+  const hasAdc = !!process.env.GOOGLE_APPLICATION_CREDENTIALS || !!process.env.GOOGLE_GHA_CREDS_PATH
+  if (dryRun && !hasAdc) {
+    log('Secret Manager lookup skipped for local dry run without ADC credentials')
+    return
+  }
+  const projectId = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || 'natureswaysoil-video'
+  const client = new SecretManagerServiceClient()
+  for (const secretName of SECRET_NAMES) {
+    if (hasValue(secretName) && !enforceSecretManagerAccess) continue
+    for (const candidate of secretCandidates(secretName)) {
+      try {
+        const [version] = await client.accessSecretVersion({ name: `projects/${projectId}/secrets/${candidate}/versions/latest` })
+        const value = version.payload?.data?.toString().trim()
+        if (value) {
+          process.env[secretName] = value
+          process.env[candidate] = value
+          log(`Loaded secret: ${candidate}${candidate === secretName ? '' : ` -> ${secretName}`}`)
+          break
+        }
+      } catch (error: any) {
+        if (isNotFoundSecretError(error)) continue
+        if (isPermissionDeniedSecretError(error)) {
+          throw new Error(`Secret Manager permission denied for ${candidate}: ${error?.message || error}`)
+        }
+        log(`Could not load secret ${candidate}: ${error?.message || error}`)
+        break
+      }
+    }
+  }
+}
+
+function readJson(file: string, fallback: any) {
+  try {
+    if (!fs.existsSync(file)) return fallback
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return fallback
+  }
+}
+
+function writeJson(file: string, data: any) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf8')
+}
+
+function loadProducts(): Product[] {
+  const raw = readJson(CONFIG_PATH, { topProducts: [] })
+  return Array.isArray(raw.topProducts) ? raw.topProducts.slice(0, Number(process.env.SEED_PRODUCT_LIMIT || 20)) : []
+}
+
+function websiteCtaUrl(product: Product) {
+  if (String(product.websiteUrl || '').trim()) return product.websiteUrl
+  return 'https://www.natureswaysoil.com'
+}
+
+async function restoreRotationStateFromGcs() {
+  if (String(process.env.ROTATION_STATE_PERSIST_TO_GCS || 'true').toLowerCase() === 'false') return
+  try {
+    const bucketName = process.env.ROTATION_STATE_GCS_BUCKET || publicBucketName()
+    const objectName = process.env.ROTATION_STATE_GCS_OBJECT || 'state/rotation-state.json'
+    const storage = new Storage()
+    const bucket = storage.bucket(bucketName)
+    const file = bucket.file(objectName)
+    const [exists] = await file.exists()
+    if (!exists) return
+    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true })
+    await file.download({ destination: STATE_PATH })
+    log('Restored rotation state from GCS', { bucketName, objectName, statePath: STATE_PATH })
+  } catch (error: any) {
+    log('Rotation state restore skipped', error?.message || error)
+  }
+}
+
+async function persistRotationStateToGcs() {
+  if (!fs.existsSync(STATE_PATH)) return
+  if (String(process.env.ROTATION_STATE_PERSIST_TO_GCS || 'true').toLowerCase() === 'false') return
+  try {
+    const bucketName = process.env.ROTATION_STATE_GCS_BUCKET || publicBucketName()
+    const objectName = process.env.ROTATION_STATE_GCS_OBJECT || 'state/rotation-state.json'
+    const storage = new Storage()
+    await storage.bucket(bucketName).upload(STATE_PATH, { destination: objectName, resumable: false, metadata: { contentType: 'application/json' } })
+    log('Persisted rotation state to GCS', { bucketName, objectName })
+  } catch (error: any) {
+    log('Rotation state persistence skipped', error?.message || error)
+  }
+}
+
+function pickProduct(products: Product[]) {
+  const state = readJson(STATE_PATH, { ...DEFAULT_STATE })
+  const preferredId = process.env.NEXT_PRODUCT_PREFERRED_ID?.trim()
+  const preferredIndex = preferredId ? products.findIndex((p) => p.id === preferredId) : -1
+  const nextCursor = preferredIndex >= 0 ? preferredIndex : (Number(state.cursor ?? -1) + 1) % products.length
+  const product = products[nextCursor]
+  const variationCount = Number(process.env.VARIATIONS_PER_PRODUCT || 5)
+  const lastVariation = state.variationByProduct?.[product.id]
+  const variationIndex = typeof lastVariation === 'number' ? (lastVariation + 1) % variationCount : 0
+  state.cursor = nextCursor
+  state.variationByProduct = state.variationByProduct || {}
+  state.variationByProduct[product.id] = variationIndex
+  state.lastRunAt = new Date().toISOString()
+  writeJson(STATE_PATH, state)
+  return { product, variationIndex, variationCount }
+}
+
+function productCreativeProfile(product: Product): CreativeProfile {
+  const creative = readJson(CREATIVE_PATH, { defaults: {}, profiles: {} })
+  return { ...(creative.defaults || {}), ...((creative.profiles || {})[product.id] || {}) }
+}
+
+function sceneQueries(scene: CreativeScene, product: Product, index: number) {
+  return buildSceneQueryPriority(scene, product, index)
+}
+
+function curatedScenePlan(product: Product, profile: CreativeProfile): { fullVoiceover: string, scenes: CreativeScene[] } | null {
+  if (!Array.isArray(profile.scenes) || !profile.scenes.length) return null
+  const scenes = profile.scenes.slice(0, 5).map((scene, index) => ({
+    name: scene.name || `scene-${index + 1}`,
+    seconds: Number(scene.seconds || 6),
+    voiceover: scene.voiceover || '',
+    brollQuery: sceneQueries(scene, product, index)[0] || product.category,
+    brollQueries: sceneQueries(scene, product, index),
+    caption: scene.caption || scene.name || product.name,
+    useProductImage: Boolean(scene.useProductImage) || index === 1 || index === profile.scenes!.length - 1
+  }))
+  const fallbackVoice = `${profile.hooks?.[0] || product.name}. ${product.description} ${profile.cta || 'See full product details at natureswaysoil.com.'}`
+  const voiceover = scenes.map((scene) => scene.voiceover).filter(Boolean).join(' ') || fallbackVoice
+  return { fullVoiceover: voiceover, scenes }
+}
+
+function fallbackScenes(product: Product, profile: CreativeProfile): CreativeScene[] {
+  const base = product.brollQueries?.length ? product.brollQueries : [product.category]
+  return [
+    { name: 'Problem', seconds: 5, voiceover: `${profile.hooks?.[0] || 'Your lawn or soil problem may start below the surface.'}`, brollQuery: base[0] || product.category },
+    { name: 'Product', seconds: 5, voiceover: `${product.name} is designed to support healthier soil and stronger-looking growth.`, brollQuery: base[1] || product.name, useProductImage: true },
+    { name: 'Application', seconds: 6, voiceover: 'Use it as part of your regular lawn, garden, pasture, or soil care routine according to label directions.', brollQuery: base[2] || 'spraying lawn' },
+    { name: 'Field Result', seconds: 6, voiceover: 'The goal is better soil support, root-zone activity, and nutrient availability.', brollQuery: base[3] || 'healthy soil close up' },
+    { name: 'CTA', seconds: 6, voiceover: profile.cta || 'See full product details at natureswaysoil.com.', brollQuery: base[4] || 'healthy green lawn', useProductImage: true }
+  ]
+}
+
+function parseJson(text: string): any {
+  try { return JSON.parse(text) } catch {
+    const match = String(text || '').match(/\{[\s\S]*\}/)
+    if (!match) return null
+    try { return JSON.parse(match[0]) } catch { return null }
+  }
+}
+
+async function generateScenePlan(product: Product, profile: CreativeProfile, variationIndex: number, variationCount: number): Promise<{ fullVoiceover: string, scenes: CreativeScene[] }> {
+  const curated = curatedScenePlan(product, profile)
+  if (curated) return curated
+  const fallback = fallbackScenes(product, profile)
+  if (String(process.env.USE_OPENAI_SCENE_PLAN || 'false').toLowerCase() !== 'true') return { fullVoiceover: fallback.map(s => s.voiceover || '').join(' '), scenes: fallback }
+  if (!hasValue('OPENAI_API_KEY')) return { fullVoiceover: fallback.map(s => s.voiceover || '').join(' '), scenes: fallback }
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  const prompt = `Create a practical 25-30 second vertical product video script for Nature's Way Soil.
+Product: ${product.name}
+Description: ${product.description}
+Category: ${product.category}
+Website: ${websiteCtaUrl(product)}
+Variation: ${variationIndex + 1} of ${variationCount}
+Audience: ${profile.audience || 'homeowners, gardeners, lawn care, land owners'}
+Angle: ${profile.angle || 'soil-first product explanation'}
+Tone: ${profile.tone || 'plainspoken and practical'}
+Rules:
+- No fantasy visuals, no cartoons, no "animation highlighting ingredients", no screen recordings.
+- Use realistic farm, lawn, soil, sprayer, pasture, garden, and product visuals only.
+- No guaranteed results.
+- No pesticide, disease, or cure claims.
+- Product should be visible by scene 2.
+- End with a direct CTA.
+- Return only JSON: {"fullVoiceover":"...","scenes":[{"name":"...","seconds":6,"voiceover":"...","brollQuery":"...","caption":"...","useProductImage":false}]}
+- Provide exactly 5 scenes.`
+  const response = await client.chat.completions.create({ model: process.env.OPENAI_MODEL || 'gpt-4o-mini', messages: [{ role: 'user', content: prompt }], temperature: 0.25, max_tokens: 700 })
+  const parsed = parseJson(response.choices[0]?.message?.content?.trim() || '')
+  if (parsed?.scenes?.length) {
+    const scenes = parsed.scenes.slice(0, 5).map((scene: any, index: number) => ({
+      name: String(scene?.name || fallback[index]?.name || `scene-${index + 1}`),
+      seconds: Number(scene?.seconds || fallback[index]?.seconds || 6),
+      voiceover: String(scene?.voiceover || fallback[index]?.voiceover || '').trim(),
+      brollQuery: String(scene?.brollQuery || fallback[index]?.brollQuery || product.category),
+      caption: String(scene?.caption || scene?.name || fallback[index]?.name || '').trim(),
+      useProductImage: Boolean(scene?.useProductImage) || index === 1 || index === 4
+    }))
+    return { fullVoiceover: String(parsed.fullVoiceover || scenes.map((s: CreativeScene) => s.voiceover || '').join(' ')), scenes }
+  }
+  return { fullVoiceover: fallback.map(s => s.voiceover || '').join(' '), scenes: fallback }
+}
+
+function pickEnv(keys: string[]): string {
+  for (const key of keys) {
+    const value = process.env[key]?.trim()
+    if (value) return value
+  }
+  return ''
+}
+
+function isHttpUrl(value: string) {
+  return /^https?:\/\//i.test(String(value || ''))
+}
+
+function isCiMandatoryPlatformMode() {
+  const setting = String(process.env.CI_MANDATORY_PLATFORMS || '').toLowerCase()
+  if (setting === 'false' || setting === 'none' || setting === 'off') return false
+  if (setting === 'all' || setting === 'enabled') return true
+  return String(process.env.CI || '').toLowerCase() === 'true'
+}
+
+function publicBucketName() {
+  return pickEnv(['GCS_PUBLIC_BUCKET', 'VIDEO_PUBLIC_BUCKET']) || DEFAULT_PUBLIC_VIDEO_BUCKET
+}
+
+function publicBucketUrlBase(bucket: string) {
+  const explicit = process.env.VIDEO_PUBLIC_URL_BASE?.replace(/\/$/, '') || ''
+  return explicit || `https://storage.googleapis.com/${bucket}`
+}
+
+async function uploadVideoForSocial(videoFileOrUrl: string): Promise<string> {
+  if (isHttpUrl(videoFileOrUrl)) return videoFileOrUrl
+  const bucketName = publicBucketName()
+  const storage = new Storage()
+  const objectName = `social-videos/${Date.now()}-${safeFileName(path.basename(videoFileOrUrl), 'mp4')}`
+  await storage.bucket(bucketName).upload(videoFileOrUrl, {
+    destination: objectName,
+    resumable: false,
+    metadata: {
+      contentType: 'video/mp4',
+      cacheControl: 'public, max-age=604800'
+    }
+  })
+  // Uniform bucket-level access is the production default. Object ACL calls
+  // fail on those buckets, so only make an object public when explicitly
+  // requested for a legacy ACL-enabled bucket.
+  if (String(process.env.GCS_MAKE_OBJECT_PUBLIC || '').toLowerCase() === 'true') {
+    await storage.bucket(bucketName).file(objectName).makePublic()
+  }
+  const publicUrl = `${publicBucketUrlBase(bucketName)}/${objectName.split('/').map(encodeURIComponent).join('/')}`
+  log('Uploaded video for social platforms', { bucketName, objectName, publicUrl })
+  return publicUrl
+}
+
+function createThumbnail(videoFile: string, product: Product): string {
+  ensureDir(OUTPUT_DIR)
+  const output = path.resolve(OUTPUT_DIR, `${safeFileName(`${product.name}-thumbnail`, 'jpg')}`)
+  execSync(`ffmpeg -y -loglevel error -i "${videoFile}" -ss 00:00:02 -vframes 1 "${output}"`, { stdio: 'inherit' })
+  return output
+}
+
+async function postToYouTube(videoFileOrUrl: string, title: string, description: string, thumbnailFile?: string): Promise<string> {
+  const clientId = pickEnv(['YT_CLIENT_ID', 'YOUTUBE_CLIENT_ID'])
+  const clientSecret = pickEnv(['YT_CLIENT_SECRET', 'YOUTUBE_CLIENT_SECRET'])
+  const refreshToken = pickEnv(['YT_REFRESH_TOKEN', 'YOUTUBE_REFRESH_TOKEN'])
+  if (!clientId || !clientSecret || !refreshToken) throw new Error('Missing YouTube OAuth credentials')
+  const oauth2Client = new google.auth.OAuth2({ clientId, clientSecret })
+  oauth2Client.setCredentials({ refresh_token: refreshToken })
+  const youtube = google.youtube({ version: 'v3', auth: oauth2Client })
+  const body = isHttpUrl(videoFileOrUrl)
+    ? (await axios.get(videoFileOrUrl, { responseType: 'stream', timeout: 120000 })).data
+    : fs.createReadStream(videoFileOrUrl)
+  const upload = await youtube.videos.insert({ part: ['snippet', 'status'], requestBody: { snippet: { title: title.slice(0, 95), description, categoryId: '22' }, status: { privacyStatus: (process.env.YT_PRIVACY_STATUS as any) || 'public' } }, media: { body } })
+  const id = upload.data.id || ''
+  if (!id) throw new Error('YouTube upload did not return video id')
+  if (thumbnailFile && fs.existsSync(thumbnailFile)) {
+    try {
+      await youtube.thumbnails.set({ videoId: id, media: { body: fs.createReadStream(thumbnailFile) } })
+    } catch (error: any) {
+      log('YouTube thumbnail upload failed', error?.message || error)
+    }
+  }
+  return id
+}
+
+async function postToInstagram(publicVideoUrl: string, captionText: string): Promise<string> {
+  const accessToken = process.env.INSTAGRAM_ACCESS_TOKEN
+  const igId = pickEnv(['INSTAGRAM_IG_ID', 'INSTAGRAM_USER_ID', 'INSTAGRAM_ACCOUNT_ID'])
+  if (!accessToken || !igId) throw new Error('Missing Instagram access token or IG ID')
+  if (!isHttpUrl(publicVideoUrl)) throw new Error('Instagram requires a public HTTPS video URL.')
+  const apiVersion = process.env.INSTAGRAM_API_VERSION || 'v20.0'
+  const host = process.env.INSTAGRAM_API_HOST || 'graph.facebook.com'
+  const baseUrl = `https://${host}/${apiVersion}`
+  const container = await axios.post(`${baseUrl}/${igId}/media`, { media_type: process.env.IG_MEDIA_TYPE || 'REELS', video_url: publicVideoUrl, caption: captionText }, { headers: { Authorization: `Bearer ${accessToken}` }, timeout: 120000 })
+  const creationId = container.data?.id
+  if (!creationId) throw new Error('Instagram did not return creation id')
+  for (let i = 0; i < 24; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10000))
+    const status = await axios.get(`${baseUrl}/${creationId}?fields=status_code`, { headers: { Authorization: `Bearer ${accessToken}` }, timeout: 30000 })
+    const code = status.data?.status_code
+    log('Instagram media status', { creationId, code })
+    if (code === 'FINISHED') break
+    if (code === 'ERROR' || code === 'EXPIRED') throw new Error(`Instagram container ${code}`)
+  }
+  const published = await axios.post(`${baseUrl}/${igId}/media_publish`, { creation_id: creationId }, { headers: { Authorization: `Bearer ${accessToken}` }, timeout: 120000 })
+  const mediaId = published.data?.id || ''
+  if (!mediaId) throw new Error('Instagram publish did not return media id')
+  return mediaId
+}
+
+async function postToFacebook(publicVideoUrl: string, captionText: string): Promise<string> {
+  const accessToken = pickEnv(['FB_PAGE_ACCESS_TOKEN', 'FACEBOOK_PAGE_ACCESS_TOKEN'])
+  const pageId = pickEnv(['FB_PAGE_ID', 'FACEBOOK_PAGE_ID'])
+  if (!accessToken || !pageId) throw new Error('Missing Facebook page access token or page ID')
+  if (!isHttpUrl(publicVideoUrl)) throw new Error('Facebook requires a public HTTPS video URL.')
+  const apiVersion = process.env.FACEBOOK_API_VERSION || process.env.INSTAGRAM_API_VERSION || 'v20.0'
+  const host = process.env.FACEBOOK_API_HOST || 'graph.facebook.com'
+  const baseUrl = `https://${host}/${apiVersion}`
+  const response = await axios.post(`${baseUrl}/${pageId}/videos`, {
+    file_url: publicVideoUrl,
+    description: captionText,
+    published: true
+  }, { headers: { Authorization: `Bearer ${accessToken}` }, timeout: 120000 })
+  const id = response.data?.id || ''
+  if (!id) throw new Error(`Facebook did not return video id: ${JSON.stringify(response.data)}`)
+  return id
+}
+
+function localFootageCandidates(product: Product) {
+  if (!fs.existsSync(FOOTAGE_DIR)) return []
+  const files = fs.readdirSync(FOOTAGE_DIR)
+    .filter((f) => /\.(mp4|mov|mkv|webm|png|jpe?g|webp)$/i.test(f))
+    .map((f) => path.resolve(FOOTAGE_DIR, f))
+  const text = `${product.name} ${product.category} ${(product.keywords || []).join(' ')}`.toLowerCase()
+  return files.sort((a, b) => {
+    const score = (file: string) => {
+      const name = path.basename(file).toLowerCase()
+      let s = 0
+      if (/dog|pet|urine|odor|kennel/.test(text) && /dog|pet|urine|odor|lawn|grass/.test(name)) s += 6
+      if (/pasture|hay|field|farm|acre/.test(text) && /pasture|hay|field|farm|acre/.test(name)) s += 6
+      if (/compost|biochar|worm|soil|garden/.test(text) && /compost|biochar|worm|soil|garden|plant/.test(name)) s += 6
+      if (/spray|hose|before|after|product|bottle|jug/.test(name)) s += 3
+      return s
+    }
+    return score(b) - score(a)
+  })
+}
+
+async function collectSceneFiles(product: Product, scenePlan: any) {
+  ensureDir(OUTPUT_DIR)
+  ensureDir(TEMP_DIR)
+  ensureDir(FOOTAGE_DIR)
+  const productImage = await downloadProductImage(product, TEMP_DIR)
+  const local = localFootageCandidates(product)
+  const usedLocal = new Set<string>()
+  const scenes: RenderScene[] = []
+  const hasKeywordMatch = (text: string, fileName: string, textPattern: RegExp, filePattern: RegExp, weight: number) =>
+    textPattern.test(text) && filePattern.test(fileName) ? weight : 0
+
+  function pickLocalForScene(scene: CreativeScene, index: number) {
+    const queries = sceneQueries(scene, product, index)
+    const sceneText = `${scene.name || ''} ${scene.caption || ''} ${queries.join(' ')}`.toLowerCase()
+    const words = sceneText.match(/[a-z0-9]+/g) || []
+    const keywords = words.filter((word) => word.length >= 4)
+    const rank = (file: string) => {
+      const name = path.basename(file).toLowerCase()
+      let score = 0
+      for (const word of keywords) if (name.includes(word)) score += 3
+      score += hasKeywordMatch(sceneText, name, /dog|pet|urine|odor|kennel/, /dog|pet|urine|odor|kennel/, 8)
+      score += hasKeywordMatch(sceneText, name, /pasture|hay|field|farm|acre/, /pasture|hay|field|farm|acre/, 8)
+      score += hasKeywordMatch(sceneText, name, /compost|biochar|worm|soil|garden/, /compost|biochar|worm|soil|garden|plant/, 8)
+      if (/spray|hose|before|after|product|bottle|jug/.test(name)) score += 2
+      return score
+    }
+    const candidate = local
+      .filter((file) => !usedLocal.has(file))
+      .map((file) => ({ file, score: rank(file) }))
+      .sort((a, b) => b.score - a.score)[0]
+    return candidate && candidate.score > 0 ? candidate.file : ''
+  }
+
+  for (const [index, rawScene] of (scenePlan.scenes || []).slice(0, 5).entries()) {
+    const scene = rawScene || {}
+    const seconds = Number(scene.seconds || 6)
+    if (scene.useProductImage && productImage) {
+      scenes.push({ file: productImage, seconds, kind: 'product', source: 'product_image' })
+      continue
+    }
+
+    const localFile = pickLocalForScene(scene, index)
+    if (localFile) {
+      usedLocal.add(localFile)
+      scenes.push({ file: localFile, seconds, kind: 'video', source: 'local', query: sceneQueries(scene, product, index)[0] || '' })
+      continue
+    }
+
+    const fetched = await fetchBrollForScene(scene, product, TEMP_DIR, index)
+    if (fetched?.file) {
+      scenes.push({
+        file: fetched.file,
+        seconds,
+        kind: fetched.kind,
+        query: fetched.query,
+        source: fetched.kind === 'photo' ? 'pexels_photo' : 'pexels_video'
+      })
+      continue
+    }
+
+    if (productImage) {
+      scenes.push({ file: productImage, seconds, kind: 'product', source: 'product_image' })
+      continue
+    }
+    log('No media source available for scene', { index: index + 1, name: scene.name, queries: sceneQueries(scene, product, index) })
+  }
+
+  if (!scenes.length) throw new Error('No b-roll or product images available. Add files to footage/, add productImageUrl, or configure PEXELS_API_KEY.')
+  return { scenes, productImage }
+}
+
+function hookText(product: Product, scenePlan: any) {
+  const firstScene = scenePlan.scenes?.[0]
+  return String(firstScene?.caption || firstScene?.name || product.name).slice(0, 80).toUpperCase()
+}
+
+async function renderVideo(product: Product, profile: CreativeProfile, scenePlan: any): Promise<string> {
+  const { scenes, productImage } = await collectSceneFiles(product, scenePlan)
+  const voiceoverFile = await createNarration(product, scenePlan, profile, TEMP_DIR)
+  const videoFile = await composeVerticalAd({
+    outputName: `${safeFileName(product.name)}-scheduled.mp4`,
+    scenes,
+    productImage,
+    voiceoverFile,
+    captionText: hookText(product, scenePlan),
+    overlayText: productOverlayText(product)
+  })
+  log('Rendered b-roll Ken Burns video', {
+    videoFile,
+    scenes: scenes.map((scene) => ({ kind: scene.kind, source: scene.source, query: scene.query, seconds: scene.seconds })),
+    productImage: !!productImage,
+    hasNarration: !!voiceoverFile
+  })
+  return videoFile
+}
+
+async function main() {
+  process.env.VIDEO_STYLE = String(process.env.VIDEO_STYLE || 'broll_ken_burns').toLowerCase()
+  process.env.VIDEO_PROVIDER = String(process.env.VIDEO_PROVIDER || 'openai_tts').toLowerCase()
+  await loadSecrets()
+  await restoreRotationStateFromGcs()
+  const products = loadProducts()
+  if (!products.length) throw new Error('No products configured')
+  const { product, variationIndex, variationCount } = pickProduct(products)
+  // NOTE: rotation state is persisted to GCS only after a successful post (see end of main()).
+  // Persisting here would advance/"burn" the cursor even when render or posting fails, silently
+  // skipping that product on the next run.
+  const profile = productCreativeProfile(product)
+  if (process.env.VIDEO_STYLE === 'broll_ken_burns' && !hasValue('PEXELS_API_KEY') && !product.productImageUrl && !fs.existsSync(FOOTAGE_DIR)) {
+    log('PREFLIGHT WARNING: no PEXELS_API_KEY, no product image, and no local footage/ dir. B-roll render will fail and nothing will post. Set PEXELS_API_KEY (or add productImageUrl / footage).')
+  }
+  log('Scheduled product selected', { videoStyle: process.env.VIDEO_STYLE, product: product.name, id: product.id, variation: `${variationIndex + 1}/${variationCount}` })
+  log('Creative mapping selected', { hasScenePlan: !!profile.scenes?.length, hasProductImage: !!product.productImageUrl, brollQueries: product.brollQueries?.length || 0 })
+  const scenePlan = await generateScenePlan(product, profile, variationIndex, variationCount)
+  log('Generated scene plan', { fullVoiceoverLength: scenePlan.fullVoiceover.length, scenes: scenePlan.scenes.map((scene: CreativeScene, index: number) => ({ idx: index + 1, name: scene.name, seconds: scene.seconds, useProductImage: !!scene.useProductImage, brollQuery: scene.brollQuery })) })
+  const platforms = Array.from(new Set((process.env.ENABLE_PLATFORMS || 'youtube,instagram,facebook').toLowerCase().split(',').map((p) => p.trim()).filter(Boolean)))
+  const mandatoryPlatformMode = isCiMandatoryPlatformMode()
+  const captions = {
+    youtube: formatCaption(product, scenePlan, 'youtube'),
+    instagram: formatCaption(product, scenePlan, 'instagram'),
+    facebook: formatCaption(product, scenePlan, 'facebook'),
+    tiktok: formatCaption(product, scenePlan, 'tiktok'),
+    twitter: formatCaption(product, scenePlan, 'tiktok'),
+    facebookGroups: formatCaption(product, scenePlan, 'facebook_groups')
+  }
+  if (String(process.env.DRY_RUN_LOG_ONLY || '').toLowerCase() === 'true') {
+    log('Dry run enabled; skipping render and social posting', {
+      videoStyle: process.env.VIDEO_STYLE,
+      videoProvider: process.env.VIDEO_PROVIDER,
+      platforms,
+      captions,
+      voiceover: scenePlan.fullVoiceover
+    })
+    return
+  }
+  const videoFile = await renderVideo(product, profile, scenePlan)
+  const thumbnailFile = createThumbnail(videoFile, product)
+
+  // Dry-run posting mode: video rendered, but skip all social publishing API calls.
+  if (String(process.env.POSTING_DRY_RUN || '').toLowerCase() === 'true') {
+    log('[DRY RUN] Video and thumbnail generated successfully. Skipping social media publishing.', {
+      videoFile,
+      thumbnailFile,
+      platforms,
+      captions,
+      voiceover: scenePlan.fullVoiceover
+    })
+    return
+  }
+
+  let publicVideoUrl = ''
+  if (platforms.includes('instagram') || platforms.includes('facebook') || platforms.includes('tiktok') || platforms.includes('facebook_groups')) {
+    publicVideoUrl = await uploadVideoForSocial(videoFile)
+  }
+
+  let posted = 0
+  const videoIds: Record<string, string> = {}
+  const platformSuccess: Record<string, boolean> = {}
+  const platformErrors: Record<string, string> = {}
+  if (platforms.includes('youtube')) {
+    try {
+      const id = await postToYouTube(videoFile, product.name, captions.youtube, thumbnailFile)
+      posted++
+      videoIds.youtubeId = id
+      platformSuccess.youtube = true
+      log('Posted to YouTube', { id })
+    } catch (error: any) {
+      platformSuccess.youtube = false
+      platformErrors.youtube = String(error?.message || error)
+      log('YouTube post failed', error?.message || error)
+    }
+  }
+  if (platforms.includes('instagram')) {
+    try {
+      const id = await postToInstagram(publicVideoUrl, captions.instagram)
+      posted++
+      videoIds.instagramId = id
+      platformSuccess.instagram = true
+      log('Posted to Instagram', { id })
+    } catch (error: any) {
+      platformSuccess.instagram = false
+      platformErrors.instagram = String(error?.message || error)
+      log('Instagram post failed', error?.message || error)
+    }
+  }
+  if (platforms.includes('facebook')) {
+    try {
+      const id = await postToFacebook(publicVideoUrl, captions.facebook)
+      posted++
+      videoIds.facebookId = id
+      platformSuccess.facebook = true
+      log('Posted to Facebook', { id })
+    } catch (error: any) {
+      platformSuccess.facebook = false
+      platformErrors.facebook = String(error?.message || error)
+      log('Facebook post failed', error?.message || error)
+    }
+  }
+  if (platforms.includes('tiktok')) {
+    try {
+      const result = await postToTikTok(publicVideoUrl, captions.tiktok)
+      const skipped = !!(result as any)?.skipped
+      if (!skipped) posted++
+      platformSuccess.tiktok = !skipped
+      if (skipped) platformErrors.tiktok = 'TikTok posting skipped'
+      log('Posted to TikTok', result)
+    } catch (error: any) {
+      platformSuccess.tiktok = false
+      platformErrors.tiktok = String(error?.message || error)
+      log('TikTok post failed', error?.message || error)
+    }
+  }
+  if (platforms.includes('twitter')) {
+    try {
+      const result = await postToTwitter(videoFile, captions.twitter)
+      const skipped = !!(result as any)?.skipped
+      if (!skipped) posted++
+      platformSuccess.twitter = !skipped
+      if (skipped) platformErrors.twitter = 'Twitter posting skipped'
+      log('Posted to Twitter', result)
+    } catch (error: any) {
+      platformSuccess.twitter = false
+      platformErrors.twitter = String(error?.message || error)
+      log('Twitter post failed', error?.message || error)
+    }
+  }
+  if (platforms.includes('facebook_groups')) {
+    try {
+      const results = await postToFacebookGroups(product, publicVideoUrl, captions.facebookGroups)
+      const successes = results.filter((item: any) => item.ok).length
+      if (successes > 0) posted += successes
+      platformSuccess.facebook_groups = successes > 0
+      if (successes === 0) platformErrors.facebook_groups = 'No Facebook group posts succeeded'
+      log('Facebook group posting completed', { attempts: results.length, successes })
+    } catch (error: any) {
+      platformSuccess.facebook_groups = false
+      platformErrors.facebook_groups = String(error?.message || error)
+      log('Facebook groups post failed', error?.message || error)
+    }
+  }
+
+  const metrics = await fetchBasicMetrics(videoIds)
+  recordPerformance({
+    productId: product.id,
+    productName: product.name,
+    hook: hookText(product, scenePlan),
+    variant: `scheduled_v${variationIndex + 1}`,
+    views: Number(metrics.youtube?.views || metrics.instagram?.views || metrics.facebook?.views || 0),
+    likes: Number((metrics.youtube?.likes || 0) + (metrics.instagram?.likes || 0) + (metrics.facebook?.likes || 0)),
+    comments: Number((metrics.youtube?.comments || 0) + (metrics.instagram?.comments || 0) + (metrics.facebook?.comments || 0)),
+    clicks: 0,
+    videoIds,
+    analyticsFile: VIDEO_ANALYTICS_FILE
+  })
+
+  if (mandatoryPlatformMode) {
+    const failedMandatory = platforms.filter((platform) => !platformSuccess[platform])
+    if (failedMandatory.length) {
+      const detail = failedMandatory.map((platform) => `${platform}: ${platformErrors[platform] || 'post did not succeed'}`).join('; ')
+      throw new Error(`Mandatory enabled platform posting failed (${detail})`)
+    }
+  }
+
+  if (posted === 0) throw new Error('No platform posts succeeded')
+  // Only now that at least one platform succeeded do we advance the cross-run cursor in GCS.
+  await persistRotationStateToGcs()
+  log('Scheduled post completed', { posted, videoFile, publicVideoUrl, thumbnailFile, videoIds, metrics })
+}
+
+main().catch((error) => { console.error('Scheduled post failed:', error?.message || error); process.exit(1) })


### PR DESCRIPTION
## What changed

- restore `scripts/post-scheduled.ts`, the B-roll/Ken Burns renderer and social publisher invoked by the sheet-row workflow
- restore its video, media, caption, platform, Facebook-group, and analytics helper modules from the repaired `social-video-automation` implementation

## Root cause

`scripts/post-sheet-row.ts` invokes `scripts/post-scheduled.ts`, but the scheduled posting implementation and its helper modules were never present on `main`.

## Impact

The sheet-row workflow can continue from row selection into video rendering, cloud upload, and enabled-platform posting.

## Validation

- `npm run typecheck`
- `npm run build`
- public Google Sheet dry-run row selection and scene construction
